### PR TITLE
Replace P2P VoteMsg with Broadcast semantics

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,12 +45,8 @@ jobs:
         run: cargo fmt --all -- --check
 
       # Run Clippy.
-      - name: Clippy checks --feature blsttc
-        run: cargo clippy --all-targets --no-default-features --features "blsttc"
-
-      # Run Clippy.
-      - name: Clippy checks --feature ed25519
-        run: cargo clippy --all-targets --no-default-features --features "ed25519"
+      - name: Clippy checks # --feature blsttc
+        run: cargo clippy --all-targets # --no-default-features --features "blsttc"
 
   check_pr_size:
     if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub mod sn_membership;
 // #[cfg(feature = "ed25519")]
 // pub mod ed25519;
 
-pub use crate::sn_membership::{Ballot, Generation, Reconfig, SignedVote, State, Vote, VoteMsg};
+pub use crate::sn_membership::{Ballot, Generation, Reconfig, SignedVote, State, Vote};
 
 // #[cfg(feature = "bad_crypto")]
 // pub use crate::bad_crypto::{PublicKey, SecretKey, Signature};

--- a/tests/net.rs
+++ b/tests/net.rs
@@ -113,13 +113,6 @@ impl Net {
         }
     }
 
-    pub fn genesis(&self) -> Result<PublicKeyShare, Error> {
-        self.procs
-            .get(0)
-            .map(State::public_key_share)
-            .ok_or(Error::NoMembers)
-    }
-
     pub fn drop_packet_from_source(&mut self, source: PublicKeyShare) {
         self.packets.get_mut(&source).map(VecDeque::pop_front);
     }
@@ -231,16 +224,6 @@ impl Net {
             .into_iter()
             .filter(|(_, queue)| !queue.is_empty())
             .collect();
-    }
-
-    pub fn force_join(&mut self, p: PublicKeyShare, member: u8) {
-        if let Some(proc) = self
-            .procs
-            .iter_mut()
-            .find(|proc| proc.public_key_share() == p)
-        {
-            proc.force_join(member);
-        }
     }
 
     pub fn enqueue_anti_entropy(&mut self, i: usize, j: usize) {


### PR DESCRIPTION
We remove the VoteMsg struct entirely, callers are now responsible for broadcasting votes to all elders using something like the following logic:
```rust
match membership.handle_signed_vote(vote) {
  Ok(Some(response_vote)) => broadcast_elders(response_vote),
  Ok(None) => () // do nothing,
  Err(e) => eprintln!("{vote:?} is faulty {e:?}");
}
```