### PR TITLE
Generic consensus module

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -50,7 +50,7 @@ impl<T: Proposition> Consensus<T> {
         if self.is_split_vote(&self.votes.values().cloned().collect())? {
             info!("[MBR] Detected split vote");
             let merge_vote = Vote {
-                gen: gen,
+                gen,
                 ballot: Ballot::Merge(self.votes.values().cloned().collect()).simplify(),
             };
             let signed_merge_vote = self.sign_vote(merge_vote)?;
@@ -80,10 +80,7 @@ impl<T: Proposition> Consensus<T> {
             // store a proof of what the network decided in our history so that we can onboard future procs.
             let ballot = Ballot::SuperMajority(self.votes.values().cloned().collect()).simplify();
 
-            let vote = Vote {
-                gen,
-                ballot,
-            };
+            let vote = Vote { gen, ballot };
             let signed_vote = self.sign_vote(vote)?;
 
             // clear our pending votes
@@ -107,10 +104,7 @@ impl<T: Proposition> Consensus<T> {
 
             info!("[MBR] broadcasting super majority");
             let ballot = Ballot::SuperMajority(self.votes.values().cloned().collect()).simplify();
-            let vote = Vote {
-                gen,
-                ballot,
-            };
+            let vote = Vote { gen, ballot };
             let signed_vote = self.sign_vote(vote)?;
             return Ok((Some(self.cast_vote(signed_vote)), None));
         }
@@ -150,15 +144,11 @@ impl<T: Proposition> Consensus<T> {
         }
     }
 
-    pub fn count_votes(
-        &self,
-        votes: &BTreeSet<SignedVote<T>>,
-    ) -> BTreeMap<BTreeSet<T>, usize> {
+    pub fn count_votes(&self, votes: &BTreeSet<SignedVote<T>>) -> BTreeMap<BTreeSet<T>, usize> {
         let mut count: BTreeMap<BTreeSet<T>, usize> = Default::default();
 
         for vote in votes.iter() {
-            let proposals =
-                BTreeSet::from_iter(vote.proposals().into_iter().map(|(_, prop)| prop));
+            let proposals = BTreeSet::from_iter(vote.proposals().into_iter().map(|(_, prop)| prop));
             let c = count.entry(proposals).or_default();
             *c += 1;
         }
@@ -223,7 +213,10 @@ impl<T: Proposition> Consensus<T> {
         }
     }
 
-    pub fn validate_vote_supersedes_existing_vote(&self, signed_vote: &SignedVote<T>) -> Result<()> {
+    pub fn validate_vote_supersedes_existing_vote(
+        &self,
+        signed_vote: &SignedVote<T>,
+    ) -> Result<()> {
         if self.votes.contains_key(&signed_vote.voter)
             && !signed_vote.supersedes(&self.votes[&signed_vote.voter])
             && !self.votes[&signed_vote.voter].supersedes(signed_vote)

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1,50 +1,77 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use blsttc::PublicKeyShare;
+use blsttc::{PublicKeyShare, SecretKeyShare};
 use log::info;
+use rand::{CryptoRng, Rng};
 
-use crate::sn_membership::{Reconfig, State};
+use crate::sn_membership::Generation;
 use crate::vote::{Ballot, Proposition, SignedVote, Vote};
 use crate::{Error, Result};
 
-impl<T: Proposition> State<T> {
+#[derive(Debug)]
+pub struct Consensus<T: Proposition> {
+    pub elders: BTreeSet<PublicKeyShare>,
+    pub secret_key: SecretKeyShare,
+    pub votes: BTreeMap<PublicKeyShare, SignedVote<T>>,
+}
+
+impl<T: Proposition> Consensus<T> {
+    pub fn from(secret_key: SecretKeyShare, elders: BTreeSet<PublicKeyShare>) -> Self {
+        Consensus::<T> {
+            secret_key,
+            elders,
+            votes: Default::default(),
+        }
+    }
+
+    pub fn random(mut rng: impl Rng + CryptoRng) -> Self {
+        Consensus::<T> {
+            secret_key: rng.gen(),
+            elders: Default::default(),
+            votes: Default::default(),
+        }
+    }
+
     pub fn public_key_share(&self) -> PublicKeyShare {
         self.secret_key.public_key_share()
     }
 
+    // handover: gen = gen
+    // membership: gen = pending_gen
+    /// Handles a signed vote
+    /// Returns the vote we cast and the reached consensus vote in case consensus was reached
     pub fn handle_signed_vote(
         &mut self,
         signed_vote: SignedVote<T>,
-    ) -> Result<Option<SignedVote<T>>> {
-        self.validate_signed_vote(&signed_vote)?;
-
+        gen: Generation,
+    ) -> Result<(Option<SignedVote<T>>, Option<SignedVote<T>>)> {
         self.log_signed_vote(&signed_vote);
 
         if self.is_split_vote(&self.votes.values().cloned().collect())? {
             info!("[MBR] Detected split vote");
             let merge_vote = Vote {
-                gen: self.pending_gen,
+                gen: gen,
                 ballot: Ballot::Merge(self.votes.values().cloned().collect()).simplify(),
             };
             let signed_merge_vote = self.sign_vote(merge_vote)?;
 
             if let Some(our_vote) = self.votes.get(&self.public_key_share()) {
-                let reconfigs_we_voted_for =
-                    BTreeSet::from_iter(our_vote.reconfigs().into_iter().map(|(_, r)| r));
-                let reconfigs_we_would_vote_for: BTreeSet<_> = signed_merge_vote
-                    .reconfigs()
+                let proposals_we_voted_for =
+                    BTreeSet::from_iter(our_vote.proposals().into_iter().map(|(_, r)| r));
+                let proposals_we_would_vote_for: BTreeSet<_> = signed_merge_vote
+                    .proposals()
                     .into_iter()
                     .map(|(_, r)| r)
                     .collect();
 
-                if reconfigs_we_voted_for == reconfigs_we_would_vote_for {
+                if proposals_we_voted_for == proposals_we_would_vote_for {
                     info!("[MBR] This vote didn't add new information, waiting for more votes...");
-                    return Ok(None);
+                    return Ok((None, None));
                 }
             }
 
             info!("[MBR] Either we haven't voted or our previous vote didn't fully overlap, merge them.");
-            return Ok(Some(self.cast_vote(signed_merge_vote)));
+            return Ok((Some(self.cast_vote(signed_merge_vote)), None));
         }
 
         if self.is_super_majority_over_super_majorities(&self.votes.values().cloned().collect())? {
@@ -54,17 +81,16 @@ impl<T: Proposition> State<T> {
             let ballot = Ballot::SuperMajority(self.votes.values().cloned().collect()).simplify();
 
             let vote = Vote {
-                gen: self.pending_gen,
+                gen,
                 ballot,
             };
             let signed_vote = self.sign_vote(vote)?;
 
-            self.history.insert(self.pending_gen, signed_vote);
             // clear our pending votes
             self.votes = Default::default();
-            self.gen = self.pending_gen;
 
-            return Ok(None);
+            // return obtained super majority over super majority (aka consensus)
+            return Ok((None, Some(signed_vote)));
         }
 
         if self.is_super_majority(&self.votes.values().cloned().collect())? {
@@ -75,31 +101,31 @@ impl<T: Proposition> State<T> {
 
                 if our_vote.vote.is_super_majority_ballot() {
                     info!("[MBR] We've already sent a super majority, waiting till we either have a split vote or SM / SM");
-                    return Ok(None);
+                    return Ok((None, None));
                 }
             }
 
             info!("[MBR] broadcasting super majority");
             let ballot = Ballot::SuperMajority(self.votes.values().cloned().collect()).simplify();
             let vote = Vote {
-                gen: self.pending_gen,
+                gen,
                 ballot,
             };
             let signed_vote = self.sign_vote(vote)?;
-            return Ok(Some(self.cast_vote(signed_vote)));
+            return Ok((Some(self.cast_vote(signed_vote)), None));
         }
 
         // We have determined that we don't yet have enough votes to take action.
         // If we have not yet voted, this is where we would contribute our vote
         if !self.votes.contains_key(&self.public_key_share()) {
             let signed_vote = self.sign_vote(Vote {
-                gen: self.pending_gen,
+                gen,
                 ballot: signed_vote.vote.ballot,
             })?;
-            return Ok(Some(self.cast_vote(signed_vote)));
+            return Ok((Some(self.cast_vote(signed_vote)), None));
         }
 
-        Ok(None)
+        Ok((None, None))
     }
 
     pub fn sign_vote(&self, vote: Vote<T>) -> Result<SignedVote<T>> {
@@ -115,8 +141,7 @@ impl<T: Proposition> State<T> {
         signed_vote
     }
 
-    fn log_signed_vote(&mut self, signed_vote: &SignedVote<T>) {
-        self.pending_gen = signed_vote.vote.gen;
+    pub fn log_signed_vote(&mut self, signed_vote: &SignedVote<T>) {
         for vote in signed_vote.unpack_votes() {
             let existing_vote = self.votes.entry(vote.voter).or_insert_with(|| vote.clone());
             if vote.supersedes(existing_vote) {
@@ -128,13 +153,13 @@ impl<T: Proposition> State<T> {
     pub fn count_votes(
         &self,
         votes: &BTreeSet<SignedVote<T>>,
-    ) -> BTreeMap<BTreeSet<Reconfig<T>>, usize> {
-        let mut count: BTreeMap<BTreeSet<Reconfig<T>>, usize> = Default::default();
+    ) -> BTreeMap<BTreeSet<T>, usize> {
+        let mut count: BTreeMap<BTreeSet<T>, usize> = Default::default();
 
         for vote in votes.iter() {
-            let reconfigs =
-                BTreeSet::from_iter(vote.reconfigs().into_iter().map(|(_, reconfig)| reconfig));
-            let c = count.entry(reconfigs).or_default();
+            let proposals =
+                BTreeSet::from_iter(vote.proposals().into_iter().map(|(_, prop)| prop));
+            let c = count.entry(proposals).or_default();
             *c += 1;
         }
 
@@ -147,7 +172,7 @@ impl<T: Proposition> State<T> {
         let voters = BTreeSet::from_iter(votes.iter().map(|v| v.voter));
         let remaining_voters = self.elders.difference(&voters).count();
 
-        // give the remaining votes to the reconfigs with the most votes.
+        // give the remaining votes to the proposals with the most votes.
         let predicted_votes = most_votes + remaining_voters;
 
         Ok(
@@ -156,7 +181,7 @@ impl<T: Proposition> State<T> {
         )
     }
 
-    fn is_super_majority(&self, votes: &BTreeSet<SignedVote<T>>) -> Result<bool> {
+    pub fn is_super_majority(&self, votes: &BTreeSet<SignedVote<T>>) -> Result<bool> {
         // TODO: super majority should always just be the largest 7 members
         let most_votes = self
             .count_votes(votes)
@@ -187,7 +212,7 @@ impl<T: Proposition> State<T> {
         Ok(3 * count_of_agreeing_super_majorities > 2 * self.elders.len())
     }
 
-    fn validate_is_elder(&self, public_key: PublicKeyShare) -> Result<()> {
+    pub fn validate_is_elder(&self, public_key: PublicKeyShare) -> Result<()> {
         if !self.elders.contains(&public_key) {
             Err(Error::NotElder {
                 public_key,
@@ -198,7 +223,7 @@ impl<T: Proposition> State<T> {
         }
     }
 
-    fn validate_vote_supersedes_existing_vote(&self, signed_vote: &SignedVote<T>) -> Result<()> {
+    pub fn validate_vote_supersedes_existing_vote(&self, signed_vote: &SignedVote<T>) -> Result<()> {
         if self.votes.contains_key(&signed_vote.voter)
             && !signed_vote.supersedes(&self.votes[&signed_vote.voter])
             && !self.votes[&signed_vote.voter].supersedes(signed_vote)
@@ -209,80 +234,23 @@ impl<T: Proposition> State<T> {
         }
     }
 
-    fn validate_voters_have_not_changed_proposals(
+    pub fn validate_voters_have_not_changed_proposals(
         &self,
         signed_vote: &SignedVote<T>,
     ) -> Result<()> {
-        // Ensure that nobody is trying to change their reconfig proposals.
-        let reconfigs: BTreeSet<(PublicKeyShare, Reconfig<T>)> = self
+        // Ensure that nobody is trying to change their Proposal proposals.
+        let proposals: BTreeSet<(PublicKeyShare, T)> = self
             .votes
             .values()
-            .flat_map(|v| v.reconfigs())
-            .chain(signed_vote.reconfigs())
+            .flat_map(|v| v.proposals())
+            .chain(signed_vote.proposals())
             .collect();
 
-        let voters = BTreeSet::from_iter(reconfigs.iter().map(|(actor, _)| actor));
-        if voters.len() != reconfigs.len() {
+        let voters = BTreeSet::from_iter(proposals.iter().map(|(actor, _)| actor));
+        if voters.len() != proposals.len() {
             Err(Error::VoterChangedVote)
         } else {
             Ok(())
-        }
-    }
-
-    pub fn validate_signed_vote(&self, signed_vote: &SignedVote<T>) -> Result<()> {
-        signed_vote.validate_signature()?;
-        self.validate_vote(&signed_vote.vote)?;
-        self.validate_is_elder(signed_vote.voter)?;
-        self.validate_vote_supersedes_existing_vote(signed_vote)?;
-        self.validate_voters_have_not_changed_proposals(signed_vote)?;
-        Ok(())
-    }
-
-    fn validate_vote(&self, vote: &Vote<T>) -> Result<()> {
-        if vote.gen != self.gen + 1 {
-            return Err(Error::VoteNotForNextGeneration {
-                vote_gen: vote.gen,
-                gen: self.gen,
-                pending_gen: self.pending_gen,
-            });
-        }
-
-        match &vote.ballot {
-            Ballot::Propose(reconfig) => self.validate_reconfig(reconfig.clone()),
-            Ballot::Merge(votes) => {
-                for child_vote in votes.iter() {
-                    if child_vote.vote.gen != vote.gen {
-                        return Err(Error::MergedVotesMustBeFromSameGen {
-                            child_gen: child_vote.vote.gen,
-                            merge_gen: vote.gen,
-                        });
-                    }
-                    self.validate_signed_vote(child_vote)?;
-                }
-                Ok(())
-            }
-            Ballot::SuperMajority(votes) => {
-                if !self.is_super_majority(
-                    &votes
-                        .iter()
-                        .flat_map(SignedVote::unpack_votes)
-                        .cloned()
-                        .collect(),
-                )? {
-                    Err(Error::SuperMajorityBallotIsNotSuperMajority)
-                } else {
-                    for child_vote in votes.iter() {
-                        if child_vote.vote.gen != vote.gen {
-                            return Err(Error::MergedVotesMustBeFromSameGen {
-                                child_gen: child_vote.vote.gen,
-                                merge_gen: vote.gen,
-                            });
-                        }
-                        self.validate_signed_vote(child_vote)?;
-                    }
-                    Ok(())
-                }
-            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,8 @@ pub mod bad_crypto;
 #[cfg(feature = "ed25519")]
 pub mod ed25519;
 
-pub use crate::sn_membership::{Generation, Reconfig, State};
+pub use crate::sn_membership::{Generation, Reconfig, Membership};
+pub use crate::consensus::Consensus;
 pub use crate::vote::{Ballot, Proposition, SignedVote, Vote};
 
 // #[cfg(feature = "bad_crypto")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,8 @@ pub mod bad_crypto;
 #[cfg(feature = "ed25519")]
 pub mod ed25519;
 
-pub use crate::sn_membership::{Generation, Reconfig, Membership};
 pub use crate::consensus::Consensus;
+pub use crate::sn_membership::{Generation, Membership, Reconfig};
 pub use crate::vote::{Ballot, Proposition, SignedVote, Vote};
 
 // #[cfg(feature = "bad_crypto")]

--- a/src/sn_membership.rs
+++ b/src/sn_membership.rs
@@ -181,12 +181,12 @@ impl<T: Proposition> Membership<T> {
             VoteResponse::Broadcast(vote) => {
                 self.pending_gen = vote.vote.gen;
                 Ok(Some(vote))
-            },
+            }
             VoteResponse::Decided(vote) => {
                 self.history.insert(self.pending_gen, vote);
                 self.gen = self.pending_gen;
                 Ok(None)
-            },
+            }
             VoteResponse::WaitingForMoreVotes => Ok(None),
         }
     }

--- a/src/vote.rs
+++ b/src/vote.rs
@@ -4,7 +4,7 @@ use blsttc::{PublicKeyShare, SignatureShare};
 use core::fmt::Debug;
 use serde::{Deserialize, Serialize};
 
-use crate::sn_membership::{Generation, Reconfig};
+use crate::sn_membership::Generation;
 use crate::{Error, Result};
 
 pub trait Proposition: Ord + Clone + Debug + Serialize {}
@@ -12,7 +12,7 @@ impl<T: Ord + Clone + Debug + Serialize> Proposition for T {}
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum Ballot<T: Proposition> {
-    Propose(Reconfig<T>),
+    Propose(T),
     Merge(BTreeSet<SignedVote<T>>),
     SuperMajority(BTreeSet<SignedVote<T>>),
 }
@@ -107,11 +107,11 @@ impl<T: Proposition> SignedVote<T> {
         }
     }
 
-    pub fn reconfigs(&self) -> BTreeSet<(PublicKeyShare, Reconfig<T>)> {
+    pub fn proposals(&self) -> BTreeSet<(PublicKeyShare, T)> {
         match &self.vote.ballot {
-            Ballot::Propose(reconfig) => BTreeSet::from_iter([(self.voter, reconfig.clone())]),
+            Ballot::Propose(proposal) => BTreeSet::from_iter([(self.voter, proposal.clone())]),
             Ballot::Merge(votes) | Ballot::SuperMajority(votes) => {
-                BTreeSet::from_iter(votes.iter().flat_map(Self::reconfigs))
+                BTreeSet::from_iter(votes.iter().flat_map(Self::proposals))
             }
         }
     }

--- a/tests/net.rs
+++ b/tests/net.rs
@@ -6,18 +6,18 @@ use std::iter;
 use blsttc::PublicKeyShare;
 use rand::prelude::{IteratorRandom, StdRng};
 use rand::Rng;
-use sn_membership::{Ballot, Error, Generation, Reconfig, SignedVote, State, Vote};
+use sn_membership::{Ballot, Error, Generation, Membership, Reconfig, SignedVote, Vote};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Packet {
     pub source: PublicKeyShare,
     pub dest: PublicKeyShare,
-    pub vote: SignedVote<u8>,
+    pub vote: SignedVote<Reconfig<u8>>,
 }
 
 #[derive(Default, Debug)]
 pub struct Net {
-    pub procs: Vec<State<u8>>,
+    pub procs: Vec<Membership<u8>>,
     pub reconfigs_by_gen: BTreeMap<Generation, BTreeSet<Reconfig<u8>>>,
     pub members_at_gen: BTreeMap<Generation, BTreeSet<u8>>,
     pub packets: BTreeMap<PublicKeyShare, VecDeque<Packet>>,
@@ -26,7 +26,7 @@ pub struct Net {
 
 impl Net {
     pub fn with_procs(n: usize, mut rng: &mut StdRng) -> Self {
-        let mut procs = Vec::from_iter(iter::repeat_with(|| State::random(&mut rng)).take(n));
+        let mut procs = Vec::from_iter(iter::repeat_with(|| Membership::random(&mut rng)).take(n));
         procs.sort_by_key(|p| p.public_key_share());
         Self {
             procs,
@@ -34,7 +34,7 @@ impl Net {
         }
     }
 
-    pub fn proc(&self, public_key: PublicKeyShare) -> Option<&State<u8>> {
+    pub fn proc(&self, public_key: PublicKeyShare) -> Option<&Membership<u8>> {
         self.procs
             .iter()
             .find(|p| p.public_key_share() == public_key)
@@ -45,7 +45,7 @@ impl Net {
         self.procs
             .iter()
             .choose(rng)
-            .map(State::public_key_share)
+            .map(Membership::public_key_share)
             .unwrap()
     }
 
@@ -55,7 +55,7 @@ impl Net {
         recursion: u8,
         faulty: &BTreeSet<PublicKeyShare>,
         rng: &mut StdRng,
-    ) -> Ballot<u8> {
+    ) -> Ballot<Reconfig<u8>> {
         match rng.gen() || recursion == 0 {
             true => Ballot::Propose(match rng.gen() {
                 true => Reconfig::Join(rng.gen()),
@@ -81,7 +81,7 @@ impl Net {
         recursion: u8,
         faulty_nodes: &BTreeSet<PublicKeyShare>,
         rng: &mut StdRng,
-    ) -> SignedVote<u8> {
+    ) -> SignedVote<Reconfig<u8>> {
         let faulty_node = faulty_nodes
             .iter()
             .choose(rng)
@@ -137,7 +137,7 @@ impl Net {
             }
         };
 
-        let dest_elders = dest_proc.elders.clone();
+        let dest_elders = dest_proc.consensus.elders.clone();
 
         let resp = dest_proc.handle_signed_vote(packet.vote);
         // println!("[NET] resp: {:?}", resp);
@@ -196,18 +196,14 @@ impl Net {
         }
     }
 
-    pub fn broadcast(&mut self, source: PublicKeyShare, vote: SignedVote<u8>) {
-        let packets =
-            Vec::from_iter(
-                self.procs
-                    .iter()
-                    .map(State::public_key_share)
-                    .map(|dest| Packet {
-                        source,
-                        dest,
-                        vote: vote.clone(),
-                    }),
-            );
+    pub fn broadcast(&mut self, source: PublicKeyShare, vote: SignedVote<Reconfig<u8>>) {
+        let packets = Vec::from_iter(self.procs.iter().map(Membership::public_key_share).map(
+            |dest| Packet {
+                source,
+                dest,
+                vote: vote.clone(),
+            },
+        ));
         self.enqueue_packets(packets);
     }
 
@@ -269,7 +265,12 @@ msc {\n
 
         // Replace process identifiers with friendlier numbers
         // 1, 2, 3 ... instead of i:3b2, i:7def, ...
-        for (idx, proc_id) in self.procs.iter().map(State::public_key_share).enumerate() {
+        for (idx, proc_id) in self
+            .procs
+            .iter()
+            .map(Membership::public_key_share)
+            .enumerate()
+        {
             let proc_id_as_str = format!("{:?}", proc_id);
             msc = msc.replace(&proc_id_as_str, &format!("{}", idx + 1));
         }

--- a/tests/sn_membership.rs
+++ b/tests/sn_membership.rs
@@ -539,10 +539,10 @@ fn test_procs_refuse_to_propose_competing_votes() -> Result<()> {
     let proc_id = proc.public_key_share();
     proc.consensus.elders = BTreeSet::from_iter([proc_id]);
 
-    proc.propose(Reconfig::Join(0 as u8))?;
+    proc.propose(Reconfig::Join(0_u8))?;
 
     // Proposing a second join reconfig for a different member should fail
-    let reconfig = Reconfig::Join(1 as u8);
+    let reconfig = Reconfig::Join(1_u8);
     assert!(matches!(
         proc.propose(reconfig),
         Err(Error::ExistingVoteIncompatibleWithNewVote)

--- a/tests/sn_membership.rs
+++ b/tests/sn_membership.rs
@@ -14,13 +14,13 @@ mod net;
 
 use quickcheck::{Arbitrary, Gen, TestResult};
 use quickcheck_macros::quickcheck;
-use sn_membership::{Ballot, Error, Generation, Reconfig, Result, SignedVote, State, Vote};
+use sn_membership::{Ballot, Error, Generation, Membership, Reconfig, Result, SignedVote, Vote};
 
 #[test]
 fn test_reject_changing_reconfig_when_one_is_in_progress() -> Result<()> {
     let mut rng = StdRng::from_seed([0u8; 32]);
-    let mut proc: State<u8> = State::random(&mut rng);
-    proc.elders = BTreeSet::from_iter([proc.public_key_share()]);
+    let mut proc: Membership<u8> = Membership::random(&mut rng);
+    proc.consensus.elders = BTreeSet::from_iter([proc.public_key_share()]);
     proc.propose(Reconfig::Join(rng.gen()))?;
     assert!(matches!(
         proc.propose(Reconfig::Join(rng.gen())),
@@ -35,8 +35,8 @@ fn test_reject_vote_from_non_member() -> Result<()> {
     let mut net = Net::with_procs(2, &mut rng);
     let p0 = net.procs[0].public_key_share();
     let p1 = net.procs[1].public_key_share();
-    net.procs[0].elders = BTreeSet::from_iter([p0]);
-    net.procs[1].elders = BTreeSet::from_iter([p0, p1]);
+    net.procs[0].consensus.elders = BTreeSet::from_iter([p0]);
+    net.procs[1].consensus.elders = BTreeSet::from_iter([p0, p1]);
 
     let vote = net.procs[1].propose(Reconfig::Join(rng.gen()))?;
     let resp = net.procs[0].handle_signed_vote(vote);
@@ -47,16 +47,16 @@ fn test_reject_vote_from_non_member() -> Result<()> {
 #[test]
 fn test_reject_join_if_actor_is_already_a_member() -> Result<()> {
     let mut rng = StdRng::from_seed([0u8; 32]);
-    let mut proc = State::<u8> {
+    let mut proc = Membership::<u8> {
         forced_reconfigs: vec![(
             0,
             BTreeSet::from_iter((0..1).map(|_| Reconfig::Join(rng.gen()))),
         )]
         .into_iter()
         .collect(),
-        ..State::random(&mut rng)
+        ..Membership::random(&mut rng)
     };
-    proc.elders = BTreeSet::from_iter([proc.public_key_share()]);
+    proc.consensus.elders = BTreeSet::from_iter([proc.public_key_share()]);
 
     let member = proc
         .members(proc.gen)?
@@ -73,16 +73,16 @@ fn test_reject_join_if_actor_is_already_a_member() -> Result<()> {
 #[test]
 fn test_reject_leave_if_actor_is_not_a_member() {
     let mut rng = StdRng::from_seed([0u8; 32]);
-    let mut proc = State::<u8> {
+    let mut proc = Membership::<u8> {
         forced_reconfigs: vec![(
             0,
             BTreeSet::from_iter((0..1).map(|_| Reconfig::Join(rng.gen()))),
         )]
         .into_iter()
         .collect(),
-        ..State::random(&mut rng)
+        ..Membership::random(&mut rng)
     };
-    proc.elders = BTreeSet::from_iter([proc.public_key_share()]);
+    proc.consensus.elders = BTreeSet::from_iter([proc.public_key_share()]);
 
     let resp = proc.propose(Reconfig::Leave(rng.gen()));
     assert!(matches!(resp, Err(Error::LeaveRequestForNonMember { .. })));
@@ -94,16 +94,16 @@ fn test_handle_vote_rejects_packet_from_previous_gen() -> Result<()> {
     let mut net = Net::with_procs(2, &mut rng);
     let a_0 = net.procs[0].public_key_share();
     let a_1 = net.procs[1].public_key_share();
-    let elders = BTreeSet::from_iter(net.procs.iter().map(State::public_key_share));
+    let elders = BTreeSet::from_iter(net.procs.iter().map(Membership::public_key_share));
     for proc in net.procs.iter_mut() {
-        proc.elders = elders.clone();
+        proc.consensus.elders = elders.clone();
     }
 
     let vote = net.procs[0].propose(Reconfig::Join(rng.gen()))?;
     let packets = net
         .procs
         .iter()
-        .map(State::public_key_share)
+        .map(Membership::public_key_share)
         .map(|dest| Packet {
             source: a_0,
             dest,
@@ -116,7 +116,7 @@ fn test_handle_vote_rejects_packet_from_previous_gen() -> Result<()> {
     let stale_packets = net
         .procs
         .iter()
-        .map(State::public_key_share)
+        .map(Membership::public_key_share)
         .map(|dest| Packet {
             source: a_1,
             dest,
@@ -125,7 +125,7 @@ fn test_handle_vote_rejects_packet_from_previous_gen() -> Result<()> {
         .collect::<Vec<_>>();
 
     net.procs[1].pending_gen = 0;
-    net.procs[1].votes = Default::default();
+    net.procs[1].consensus.votes = Default::default();
 
     assert_eq!(packets.len(), 2); // two members in the network
     assert_eq!(stale_packets.len(), 2);
@@ -150,7 +150,7 @@ fn test_handle_vote_rejects_packet_from_previous_gen() -> Result<()> {
 #[test]
 fn test_reject_votes_with_invalid_signatures() -> Result<()> {
     let mut rng = StdRng::from_seed([0u8; 32]);
-    let mut proc: State<u8> = State::random(&mut rng);
+    let mut proc: Membership<u8> = Membership::random(&mut rng);
     let ballot = Ballot::Propose(Reconfig::Join(rng.gen()));
     let gen = proc.gen + 1;
     let voter = rng.gen::<SecretKeyShare>().public_key_share();
@@ -171,9 +171,9 @@ fn test_split_vote() -> Result<()> {
     for nprocs in 1..7 {
         let mut net = Net::with_procs(nprocs, &mut rng);
 
-        let elders = BTreeSet::from_iter(net.procs.iter().map(State::public_key_share));
+        let elders = BTreeSet::from_iter(net.procs.iter().map(Membership::public_key_share));
         for proc in net.procs.iter_mut() {
-            proc.elders = elders.clone();
+            proc.consensus.elders = elders.clone();
         }
 
         for i in 0..net.procs.len() {
@@ -216,9 +216,9 @@ fn test_round_robin_split_vote() -> Result<()> {
     for nprocs in 1..7 {
         let mut net = Net::with_procs(nprocs, &mut rng);
 
-        let elders = BTreeSet::from_iter(net.procs.iter().map(State::public_key_share));
+        let elders = BTreeSet::from_iter(net.procs.iter().map(Membership::public_key_share));
         for proc in net.procs.iter_mut() {
-            proc.elders = elders.clone();
+            proc.consensus.elders = elders.clone();
         }
 
         for i in 0..net.procs.len() {
@@ -262,9 +262,9 @@ fn test_onboarding_across_many_generations() -> Result<()> {
     let p0 = net.procs[0].public_key_share();
     let p1 = net.procs[1].public_key_share();
 
-    let elders = BTreeSet::from_iter(net.procs.iter().map(State::public_key_share));
+    let elders = BTreeSet::from_iter(net.procs.iter().map(Membership::public_key_share));
     for proc in net.procs.iter_mut() {
-        proc.elders = elders.clone();
+        proc.consensus.elders = elders.clone();
     }
 
     let vote = net.procs[0].propose(Reconfig::Join(1)).unwrap();
@@ -310,9 +310,9 @@ fn test_simple_proposal() -> Result<()> {
     let mut rng = StdRng::from_seed([0u8; 32]);
     let mut net = Net::with_procs(3, &mut rng);
 
-    let elders = BTreeSet::from_iter(net.procs.iter().map(State::public_key_share));
+    let elders = BTreeSet::from_iter(net.procs.iter().map(Membership::public_key_share));
     for proc in net.procs.iter_mut() {
-        proc.elders = elders.clone();
+        proc.consensus.elders = elders.clone();
     }
 
     let p0 = net.procs[0].public_key_share();
@@ -408,9 +408,9 @@ fn test_interpreter_qc1() -> Result<()> {
     let mut net = Net::with_procs(2, &mut rng);
     let p0 = net.procs[0].public_key_share();
 
-    let elders = BTreeSet::from_iter(net.procs.iter().map(State::public_key_share));
+    let elders = BTreeSet::from_iter(net.procs.iter().map(Membership::public_key_share));
     for proc in net.procs.iter_mut() {
-        proc.elders = elders.clone();
+        proc.consensus.elders = elders.clone();
     }
 
     let reconfig = Reconfig::Join(1);
@@ -450,9 +450,9 @@ fn test_interpreter_qc2() -> Result<()> {
     let mut net = Net::with_procs(3, &mut rng);
     let p0 = net.procs[0].public_key_share();
 
-    let elders = BTreeSet::from_iter(net.procs.iter().map(State::public_key_share));
+    let elders = BTreeSet::from_iter(net.procs.iter().map(Membership::public_key_share));
     for proc in net.procs.iter_mut() {
-        proc.elders = elders.clone();
+        proc.consensus.elders = elders.clone();
     }
 
     let vote = net.procs[0].propose(Reconfig::Join(1))?;
@@ -470,7 +470,7 @@ fn test_interpreter_qc2() -> Result<()> {
     let expected_members = net.procs[0].members(net.procs[0].pending_gen)?;
     for p in net.procs.iter() {
         assert_eq!(p.gen, p.pending_gen);
-        assert_eq!(p.votes, Default::default());
+        assert_eq!(p.consensus.votes, Default::default());
         assert_eq!(p.members(p.gen)?, expected_members);
     }
 
@@ -482,9 +482,9 @@ fn test_interpreter_qc3() {
     let mut rng = StdRng::from_seed([0u8; 32]);
     let mut net = Net::with_procs(4, &mut rng);
 
-    let elders = BTreeSet::from_iter(net.procs.iter().map(State::public_key_share));
+    let elders = BTreeSet::from_iter(net.procs.iter().map(Membership::public_key_share));
     for proc in net.procs.iter_mut() {
-        proc.elders = elders.clone();
+        proc.consensus.elders = elders.clone();
     }
 
     let p0 = net.procs[0].public_key_share();
@@ -535,19 +535,20 @@ fn test_interpreter_qc3() {
 #[test]
 fn test_procs_refuse_to_propose_competing_votes() -> Result<()> {
     let rng = StdRng::from_seed([0u8; 32]);
-    let mut proc = State::random(rng);
+    let mut proc = Membership::random(rng);
     let proc_id = proc.public_key_share();
-    proc.elders = BTreeSet::from_iter([proc_id]);
+    proc.consensus.elders = BTreeSet::from_iter([proc_id]);
 
-    proc.propose(Reconfig::Join(0))?;
+    proc.propose(Reconfig::Join(0 as u8))?;
 
     // Proposing a second join reconfig for a different member should fail
-    let reconfig = Reconfig::Join(1);
+    let reconfig = Reconfig::Join(1 as u8);
     assert!(matches!(
         proc.propose(reconfig),
         Err(Error::ExistingVoteIncompatibleWithNewVote)
     ));
     assert!(!proc
+        .consensus
         .votes
         .get(&proc_id)
         .unwrap()
@@ -562,7 +563,7 @@ fn test_procs_refuse_to_propose_competing_votes() -> Result<()> {
 #[test]
 fn test_validate_reconfig_rejects_when_members_at_capacity() -> Result<()> {
     let rng = StdRng::from_seed([0u8; 32]);
-    let mut proc = State::random(rng);
+    let mut proc = Membership::random(rng);
 
     for m in 0..7 {
         proc.force_join(m);
@@ -585,9 +586,9 @@ fn test_bft_consensus_qc1() -> Result<()> {
         net.procs[5].public_key_share(),
     ]);
 
-    let elders = BTreeSet::from_iter(net.procs.iter().map(State::public_key_share));
+    let elders = BTreeSet::from_iter(net.procs.iter().map(Membership::public_key_share));
     for p in net.procs.iter_mut() {
-        p.elders = elders.clone();
+        p.consensus.elders = elders.clone();
     }
 
     // send a randomized packet
@@ -630,7 +631,7 @@ fn test_bft_consensus_qc1() -> Result<()> {
     // BFT TERMINATION PROPERTY: all honest procs have decided ==>
     for p in honest_procs.iter() {
         assert_eq!(p.gen, p.pending_gen);
-        assert_eq!(p.votes, BTreeMap::default());
+        assert_eq!(p.consensus.votes, BTreeMap::default());
     }
 
     // BFT AGREEMENT PROPERTY: all honest procs have decided on the same values
@@ -662,9 +663,9 @@ fn prop_interpreter(n: u8, instructions: Vec<Instruction>, seed: u128) -> eyre::
 
     let mut net = Net::with_procs(n, &mut rng);
 
-    let elders = BTreeSet::from_iter(net.procs.iter().map(State::public_key_share));
+    let elders = BTreeSet::from_iter(net.procs.iter().map(Membership::public_key_share));
     for proc in net.procs.iter_mut() {
-        proc.elders = elders.clone();
+        proc.consensus.elders = elders.clone();
     }
 
     for instruction in instructions {
@@ -686,18 +687,21 @@ fn prop_interpreter(n: u8, instructions: Vec<Instruction>, seed: u128) -> eyre::
                         assert!(q.members(q.gen)?.contains(&p));
                     }
                     Err(Error::NotElder { .. }) => {
-                        assert!(!q.elders.contains(&q.public_key_share()));
+                        assert!(!q.consensus.elders.contains(&q.public_key_share()));
                     }
                     Err(Error::ExistingVoteIncompatibleWithNewVote) => {
                         // This proc has already committed to a vote this round
 
                         // This proc has already committed to a vote
-                        assert!(!q.votes.get(&q.public_key_share()).unwrap().supersedes(
-                            &q.sign_vote(Vote {
+                        assert!(!q
+                            .consensus
+                            .votes
+                            .get(&q.public_key_share())
+                            .unwrap()
+                            .supersedes(&q.sign_vote(Vote {
                                 ballot: Ballot::Propose(reconfig),
                                 gen: q.gen,
-                            })?
-                        ));
+                            })?));
                     }
                     Err(err) => {
                         // invalid request.
@@ -722,17 +726,22 @@ fn prop_interpreter(n: u8, instructions: Vec<Instruction>, seed: u128) -> eyre::
                         assert!(!q.members(q.gen)?.contains(&p));
                     }
                     Err(Error::NotElder { .. }) => {
-                        assert!(!q.elders.contains(&q.public_key_share()));
+                        assert!(!q.consensus.elders.contains(&q.public_key_share()));
                     }
                     Err(Error::ExistingVoteIncompatibleWithNewVote) => {
                         // This proc has already committed to a vote
-                        assert!(!q.votes.get(&q.public_key_share()).unwrap().supersedes(
-                            &q.sign_vote(Vote {
-                                ballot: Ballot::Propose(reconfig),
-                                gen: q.gen,
-                            })
+                        assert!(!q
+                            .consensus
+                            .votes
+                            .get(&q.public_key_share())
                             .unwrap()
-                        ))
+                            .supersedes(
+                                &q.sign_vote(Vote {
+                                    ballot: Ballot::Propose(reconfig),
+                                    gen: q.gen,
+                                })
+                                .unwrap()
+                            ))
                     }
                     Err(err) => {
                         // invalid request.
@@ -774,10 +783,10 @@ fn prop_interpreter(n: u8, instructions: Vec<Instruction>, seed: u128) -> eyre::
 
     // We should have no more pending votes.
     for p in net.procs.iter() {
-        assert_eq!(p.votes, Default::default());
+        assert_eq!(p.consensus.votes, Default::default());
     }
 
-    let mut procs_by_gen: BTreeMap<Generation, Vec<State<u8>>> = Default::default();
+    let mut procs_by_gen: BTreeMap<Generation, Vec<Membership<u8>>> = Default::default();
 
     for proc in net.procs {
         procs_by_gen.entry(proc.gen).or_default().push(proc);
@@ -835,7 +844,7 @@ fn prop_interpreter(n: u8, instructions: Vec<Instruction>, seed: u128) -> eyre::
     let proc_at_max_gen = procs_by_gen[max_gen].get(0).ok_or(Error::NoMembers)?;
     assert!(super_majority(
         procs_by_gen[max_gen].len(),
-        proc_at_max_gen.elders.len()
+        proc_at_max_gen.consensus.elders.len()
     ));
 
     Ok(TestResult::passed())
@@ -857,13 +866,13 @@ fn prop_validate_reconfig(
         return Ok(TestResult::discard());
     }
 
-    let mut proc = State::random(&mut rng);
+    let mut proc = Membership::random(&mut rng);
 
     for m in initial_members.iter().copied() {
         proc.force_join(m);
     }
 
-    proc.elders = iter::repeat_with(|| rng.gen::<SecretKeyShare>().public_key_share())
+    proc.consensus.elders = iter::repeat_with(|| rng.gen::<SecretKeyShare>().public_key_share())
         .take(num_elders as usize)
         .chain(iter::once(proc.public_key_share()))
         .collect();
@@ -933,9 +942,9 @@ fn prop_bft_consensus(
             .map(|idx| net.procs[idx as usize].public_key_share()),
     );
 
-    let elders = BTreeSet::from_iter(net.procs.iter().map(State::public_key_share));
+    let elders = BTreeSet::from_iter(net.procs.iter().map(Membership::public_key_share));
     for p in net.procs.iter_mut() {
-        p.elders = elders.clone();
+        p.consensus.elders = elders.clone();
     }
 
     let n_actions = rng.gen::<u8>() % 4;
@@ -962,7 +971,7 @@ fn prop_bft_consensus(
                     .procs
                     .iter_mut()
                     .filter(|p| !faulty.contains(&p.public_key_share())) // filter out faulty nodes
-                    .filter(|p| p.elders.contains(&p.public_key_share())) // filter out non-members
+                    .filter(|p| p.consensus.elders.contains(&p.public_key_share())) // filter out non-members
                     .filter(|p| p.gen != p.pending_gen) // filter out nodes who have already voted this round
                     .choose(&mut rng)
                 {
@@ -1012,7 +1021,7 @@ fn prop_bft_consensus(
 
     // BFT TERMINATION PROPERTY: all honest procs have decided ==>
     for p in honest_procs.iter() {
-        assert_eq!(p.votes, Default::default());
+        assert_eq!(p.consensus.votes, Default::default());
         assert_eq!(p.gen, p.pending_gen);
     }
 


### PR DESCRIPTION
- make a generic `Consensus<T>` struct that deals with the consensus core algo
- make a `Membership<T>` struct (the old `State`) that uses `Consensus<Reconfig<T>>` as consensus backend
- rename reconfig to proposal in Vote and Consensus code (as they are not related to reconfig anymore)
- adapt types in tests where needed