### PR TITLE
feat(agg-sig): move to blsttc::PublicKeySet from Set<PublicKeyShare>

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,4 @@
-use blsttc::PublicKeyShare;
 use core::fmt::Debug;
-use std::collections::BTreeSet;
 use thiserror::Error;
 
 use crate::{Generation, UniqueSectionId};
@@ -11,11 +9,6 @@ pub enum Error {
     IO(#[from] std::io::Error),
     #[error("The operation requested assumes we have at least one member")]
     NoMembers,
-    #[error("Packet was not destined for this actor: {dest:?} != {actor:?}")]
-    WrongDestination {
-        dest: PublicKeyShare,
-        actor: PublicKeyShare,
-    },
     #[error("We can not accept any new join requests, network member size is at capacity")]
     MembersAtCapacity,
     #[error("An existing member can not request to join again")]
@@ -38,11 +31,8 @@ pub enum Error {
         vote_gen: UniqueSectionId,
         gen: UniqueSectionId,
     },
-    #[error("({public_key:?} is not in {elders:?})")]
-    NotElder {
-        public_key: PublicKeyShare,
-        elders: BTreeSet<PublicKeyShare>,
-    },
+    #[error("The voter is not an elder")]
+    NotElder,
     #[error("Voter changed their vote")]
     VoterChangedVote,
     #[error("Existing vote not compatible with new vote")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,3 +25,4 @@ pub use crate::vote::{Ballot, Proposition, SignedVote, Vote};
 pub mod error;
 pub use crate::error::Error;
 pub type Result<T> = std::result::Result<T, Error>;
+pub type NodeId = u8;

--- a/tests/handover_net.rs
+++ b/tests/handover_net.rs
@@ -3,12 +3,12 @@ use std::fs::File;
 use std::io::Write;
 use std::iter;
 
-use blsttc::PublicKeyShare;
+use blsttc::SecretKeySet;
 use rand::prelude::{IteratorRandom, StdRng};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 
-use sn_membership::{Ballot, Error, Handover, Result, SignedVote, Vote};
+use sn_membership::{Ballot, Error, Handover, NodeId, Result, SignedVote, Vote};
 
 // dummy proposal for tests
 #[derive(Clone, Debug, Eq, PartialOrd, Ord, PartialEq, Serialize, Deserialize)]
@@ -16,8 +16,8 @@ pub struct DummyProposal(pub u64);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Packet {
-    pub source: PublicKeyShare,
-    pub dest: PublicKeyShare,
+    pub source: NodeId,
+    pub dest: NodeId,
     pub vote: SignedVote<DummyProposal>,
 }
 
@@ -25,14 +25,22 @@ pub struct Packet {
 pub struct Net {
     pub procs: Vec<Handover<DummyProposal>>,
     pub proposals: BTreeSet<DummyProposal>,
-    pub packets: BTreeMap<PublicKeyShare, VecDeque<Packet>>,
+    pub packets: BTreeMap<NodeId, VecDeque<Packet>>,
     pub delivered_packets: Vec<Packet>,
 }
 
 impl Net {
-    pub fn with_procs(n: usize, mut rng: &mut StdRng) -> Self {
-        let mut procs = Vec::from_iter(iter::repeat_with(|| Handover::random(&mut rng, 0)).take(n));
-        procs.sort_by_key(|p| p.public_key_share());
+    pub fn with_procs(threshold: usize, n: usize, mut rng: &mut StdRng) -> Self {
+        let elders_sk = SecretKeySet::random(threshold, &mut rng);
+
+        let procs = Vec::from_iter((1..=n).into_iter().map(|i| {
+            Handover::from(
+                (i as u8, elders_sk.secret_key_share(i)),
+                elders_sk.public_keys(),
+                n,
+                0,
+            )
+        }));
         Self {
             procs,
             ..Default::default()
@@ -40,10 +48,8 @@ impl Net {
     }
 
     #[allow(dead_code)]
-    pub fn proc(&self, public_key_share: PublicKeyShare) -> Option<&Handover<DummyProposal>> {
-        self.procs
-            .iter()
-            .find(|p| p.public_key_share() == public_key_share)
+    pub fn proc(&self, id: NodeId) -> Option<&Handover<DummyProposal>> {
+        self.procs.iter().find(|p| p.id() == id)
     }
 
     pub fn consensus_value(&self, proc: usize) -> Option<DummyProposal> {
@@ -59,12 +65,8 @@ impl Net {
 
     /// Pick a random public key from the set of procs
     #[allow(dead_code)]
-    pub fn gen_public_key(&self, rng: &mut StdRng) -> PublicKeyShare {
-        self.procs
-            .iter()
-            .choose(rng)
-            .map(Handover::public_key_share)
-            .unwrap()
+    pub fn pick_id(&self, rng: &mut StdRng) -> NodeId {
+        self.procs.iter().choose(rng).unwrap().id()
     }
 
     /// Generate a randomized ballot
@@ -72,7 +74,7 @@ impl Net {
     pub fn gen_ballot(
         &self,
         recursion: u8,
-        faulty: &BTreeSet<PublicKeyShare>,
+        faulty: &BTreeSet<NodeId>,
         rng: &mut StdRng,
     ) -> Ballot<DummyProposal> {
         match rng.gen() || recursion == 0 {
@@ -99,7 +101,7 @@ impl Net {
     pub fn gen_faulty_vote(
         &self,
         recursion: u8,
-        faulty_nodes: &BTreeSet<PublicKeyShare>,
+        faulty_nodes: &BTreeSet<NodeId>,
         rng: &mut StdRng,
     ) -> SignedVote<DummyProposal> {
         let faulty_node = faulty_nodes
@@ -113,10 +115,10 @@ impl Net {
             ballot: self.gen_ballot(recursion, faulty_nodes, rng),
         };
 
-        let mut signed_vote = faulty_node.sign_vote(vote).unwrap();
-        let node_to_impersonate = self.procs.iter().choose(rng).unwrap().public_key_share();
-        signed_vote.voter = node_to_impersonate;
-        signed_vote
+        SignedVote {
+            voter: self.pick_id(rng),
+            ..faulty_node.sign_vote(vote).unwrap()
+        }
     }
 
     /// Generate a faulty random packet
@@ -124,22 +126,22 @@ impl Net {
     pub fn gen_faulty_packet(
         &self,
         recursion: u8,
-        faulty: &BTreeSet<PublicKeyShare>,
+        faulty: &BTreeSet<NodeId>,
         rng: &mut StdRng,
     ) -> Packet {
         Packet {
             source: *faulty.iter().choose(rng).unwrap(),
+            dest: self.pick_id(rng),
             vote: self.gen_faulty_vote(recursion, faulty, rng),
-            dest: self.gen_public_key(rng),
         }
     }
 
     #[allow(dead_code)]
-    pub fn drop_packet_from_source(&mut self, source: PublicKeyShare) {
+    pub fn drop_packet_from_source(&mut self, source: NodeId) {
         self.packets.get_mut(&source).map(VecDeque::pop_front);
     }
 
-    pub fn deliver_packet_from_source(&mut self, source: PublicKeyShare) -> Result<()> {
+    pub fn deliver_packet_from_source(&mut self, source: NodeId) -> Result<()> {
         let packet = match self.packets.get_mut(&source).map(|ps| ps.pop_front()) {
             Some(Some(p)) => p,
             _ => return Ok(()), // nothing to do
@@ -148,8 +150,8 @@ impl Net {
 
         self.delivered_packets.push(packet.clone());
 
-        let dest = packet.dest;
-        let dest_proc = match self.procs.iter_mut().find(|p| p.public_key_share() == dest) {
+        let source_elders = self.proc(source).unwrap().consensus.elders.clone();
+        let dest_proc = match self.procs.iter_mut().find(|p| p.id() == packet.dest) {
             Some(proc) => proc,
             None => {
                 // println!("[NET] destination proc does not exist, dropping packet");
@@ -157,27 +159,16 @@ impl Net {
             }
         };
 
-        let dest_elders = dest_proc.consensus.elders.clone();
-
         let resp = dest_proc.handle_signed_vote(packet.vote);
         // println!("[NET] resp: {:?}", resp);
         match resp {
             Ok(Some(vote)) => {
-                let dest_actor = dest_proc.public_key_share();
+                let dest_actor = dest_proc.id();
                 self.broadcast(dest_actor, vote);
             }
             Ok(None) => {}
-            Err(Error::NotElder {
-                public_key: voter,
-                elders,
-            }) => {
-                assert_eq!(elders, dest_elders);
-                assert!(
-                    !dest_elders.contains(&voter),
-                    "{:?} should not be in {:?}",
-                    source,
-                    dest_elders
-                );
+            Err(Error::NotElder) => {
+                assert_ne!(dest_proc.consensus.elders, source_elders);
             }
             Err(Error::VoteWithInvalidUniqueSectionId { vote_gen, gen }) => {
                 assert!(vote_gen != gen);
@@ -198,14 +189,12 @@ impl Net {
         }
     }
 
-    pub fn broadcast(&mut self, source: PublicKeyShare, vote: SignedVote<DummyProposal>) {
-        let packets = Vec::from_iter(self.procs.iter().map(Handover::public_key_share).map(
-            |dest| Packet {
-                source,
-                dest,
-                vote: vote.clone(),
-            },
-        ));
+    pub fn broadcast(&mut self, source: NodeId, vote: SignedVote<DummyProposal>) {
+        let packets = Vec::from_iter(self.procs.iter().map(Handover::id).map(|dest| Packet {
+            source,
+            dest,
+            vote: vote.clone(),
+        }));
         self.enqueue_packets(packets);
     }
 
@@ -225,8 +214,8 @@ impl Net {
     }
 
     pub fn enqueue_anti_entropy(&mut self, i: usize, j: usize) {
-        let dest = self.procs[i].public_key_share();
-        let source = self.procs[j].public_key_share();
+        let dest = self.procs[i].id();
+        let source = self.procs[j].id();
 
         self.enqueue_packets(self.procs[j].anti_entropy().into_iter().map(|vote| Packet {
             source,
@@ -246,7 +235,7 @@ msc {\n
         let procs = self
             .procs
             .iter()
-            .map(|p| p.public_key_share())
+            .map(|p| p.id())
             .collect::<BTreeSet<_>>() // sort by actor id
             .into_iter()
             .map(|id| format!("{:?}", id))
@@ -260,20 +249,7 @@ msc {\n
                 packet.source, packet.dest, packet.vote
             ));
         }
-
         msc.push_str("}\n");
-
-        // Replace process identifiers with friendlier numbers
-        // 1, 2, 3 ... instead of i:3b2, i:7def, ...
-        for (idx, proc_id) in self
-            .procs
-            .iter()
-            .map(Handover::public_key_share)
-            .enumerate()
-        {
-            let proc_id_as_str = format!("{:?}", proc_id);
-            msc = msc.replace(&proc_id_as_str, &format!("{}", idx + 1));
-        }
 
         let mut msc_file = File::create(name)?;
         msc_file.write_all(msc.as_bytes())?;

--- a/tests/sn_handover.rs
+++ b/tests/sn_handover.rs
@@ -1,21 +1,25 @@
+use blsttc::{SecretKeySet, SecretKeyShare};
 use rand::{prelude::StdRng, Rng, SeedableRng};
 
 mod handover_net;
 use handover_net::{DummyProposal, Net};
-
-use blsttc::SecretKeyShare;
-use std::collections::BTreeSet;
-
 use sn_membership::{Ballot, Error, Handover, Result, SignedVote, Vote};
 
 #[test]
 fn test_handover_reject_voter_changing_proposal_when_one_is_in_progress() -> Result<()> {
     let mut rng = StdRng::from_seed([0u8; 32]);
-    let mut proc: Handover<u8> = Handover::random(&mut rng, 0);
-    proc.consensus.elders = BTreeSet::from_iter([proc.public_key_share()]);
-    proc.propose(rng.gen())?;
+    let elders_sk = SecretKeySet::random(0, &mut rng);
+    let mut proc: Handover<u8> = Handover::from(
+        (0, elders_sk.secret_key_share(0)),
+        elders_sk.public_keys(),
+        1,
+        0,
+    );
+
+    proc.propose(111)?;
+
     assert!(matches!(
-        proc.propose(rng.gen()),
+        dbg!(proc.propose(222)),
         Err(Error::ExistingVoteIncompatibleWithNewVote { .. })
     ));
     Ok(())
@@ -24,15 +28,24 @@ fn test_handover_reject_voter_changing_proposal_when_one_is_in_progress() -> Res
 #[test]
 fn test_handover_reject_vote_from_non_member() -> Result<()> {
     let mut rng = StdRng::from_seed([0u8; 32]);
-    let mut net = Net::with_procs(2, &mut rng);
-    let p0 = net.procs[0].public_key_share();
-    let p1 = net.procs[1].public_key_share();
-    net.procs[0].consensus.elders = BTreeSet::from_iter([p0]);
-    net.procs[1].consensus.elders = BTreeSet::from_iter([p0, p1]);
+    let elders_sk = SecretKeySet::random(0, &mut rng);
+    let mut p0 = Handover::<u8>::from(
+        (0, elders_sk.secret_key_share(0)),
+        elders_sk.public_keys(),
+        1,
+        0,
+    );
+    let elders_sk = SecretKeySet::random(0, &mut rng);
+    let mut p1 = Handover::<u8>::from(
+        (1, elders_sk.secret_key_share(1)),
+        elders_sk.public_keys(),
+        1,
+        0,
+    );
 
-    let vote = net.procs[1].propose(DummyProposal(rng.gen()))?;
-    let resp = net.procs[0].handle_signed_vote(vote);
-    assert!(matches!(resp, Err(Error::NotElder { .. })));
+    let vote = p1.propose(111)?;
+    let resp = p0.handle_signed_vote(vote);
+    assert!(matches!(dbg!(resp), Err(Error::InvalidElderSignature)));
     Ok(())
 }
 
@@ -40,11 +53,7 @@ fn test_handover_reject_vote_from_non_member() -> Result<()> {
 fn test_handover_handle_vote_rejects_packet_from_bad_gen() {
     // make net with 2 elders
     let mut rng = StdRng::from_seed([0u8; 32]);
-    let mut net = Net::with_procs(2, &mut rng);
-    let elders = BTreeSet::from_iter(net.procs.iter().map(Handover::public_key_share));
-    for proc in net.procs.iter_mut() {
-        proc.consensus.elders = elders.clone();
-    }
+    let mut net = Net::with_procs(1, 2, &mut rng);
 
     // one elder votes with a different generation
     net.procs[1].gen = 401;
@@ -63,10 +72,16 @@ fn test_handover_handle_vote_rejects_packet_from_bad_gen() {
 #[test]
 fn test_handover_reject_votes_with_invalid_signatures() -> Result<()> {
     let mut rng = StdRng::from_seed([0u8; 32]);
-    let mut proc: Handover<u8> = Handover::random(&mut rng, 0);
+    let elders_sk = SecretKeySet::random(0, &mut rng);
+    let mut proc = Handover::<u8>::from(
+        (0, elders_sk.secret_key_share(0)),
+        elders_sk.public_keys(),
+        1,
+        0,
+    );
     let ballot = Ballot::Propose(rng.gen());
     let gen = proc.gen;
-    let voter = rng.gen::<SecretKeyShare>().public_key_share();
+    let voter = 1;
     let bytes = bincode::serialize(&(&ballot, &gen))?;
     let sig = rng.gen::<SecretKeyShare>().sign(&bytes);
     let vote = Vote { gen, ballot };
@@ -85,15 +100,11 @@ fn test_handover_split_vote() -> eyre::Result<()> {
         println!("[TEST] testing with {} elders", nprocs);
 
         // make network of nprocs elders
-        let mut net = Net::with_procs(nprocs, &mut rng);
-        let elders = BTreeSet::from_iter(net.procs.iter().map(Handover::public_key_share));
-        for proc in net.procs.iter_mut() {
-            proc.consensus.elders = elders.clone();
-        }
+        let mut net = Net::with_procs((nprocs * 2 + 2) / 3, nprocs, &mut rng);
 
         // make each elder propose a different thing
         for i in 0..net.procs.len() {
-            let a_i = net.procs[i].public_key_share();
+            let a_i = net.procs[i].id();
             let vote = net.procs[i].propose(DummyProposal(i as u64))?;
             net.broadcast(a_i, vote);
         }
@@ -129,15 +140,11 @@ fn test_handover_round_robin_split_vote() -> eyre::Result<()> {
         println!("[TEST] testing with {} elders", nprocs);
 
         // make network of nprocs elders
-        let mut net = Net::with_procs(nprocs, &mut rng);
-        let elders = BTreeSet::from_iter(net.procs.iter().map(Handover::public_key_share));
-        for proc in net.procs.iter_mut() {
-            proc.consensus.elders = elders.clone();
-        }
+        let mut net = Net::with_procs(((nprocs + 1) * 2 / 3).min(nprocs - 1), nprocs, &mut rng);
 
         // make each elder propose a different thing
         for i in 0..net.procs.len() {
-            let a_i = net.procs[i].public_key_share();
+            let a_i = net.procs[i].id();
             let vote = net.procs[i].propose(DummyProposal(i as u64))?;
             net.broadcast(a_i, vote);
         }
@@ -145,7 +152,7 @@ fn test_handover_round_robin_split_vote() -> eyre::Result<()> {
         // send all the votes before letting others react
         while !net.packets.is_empty() {
             for i in 0..net.procs.len() {
-                net.deliver_packet_from_source(net.procs[i].public_key_share())?;
+                net.deliver_packet_from_source(net.procs[i].id())?;
             }
         }
 
@@ -180,14 +187,10 @@ fn test_handover_simple_proposal() {
     // make network of n elders
     let n = 4;
     let mut rng = StdRng::from_seed([0u8; 32]);
-    let mut net = Net::with_procs(n, &mut rng);
-    let elders = BTreeSet::from_iter(net.procs.iter().map(Handover::public_key_share));
-    for proc in net.procs.iter_mut() {
-        proc.consensus.elders = elders.clone();
-    }
+    let mut net = Net::with_procs((n * 2 + 2) / 3, n, &mut rng);
 
     // release a proposal
-    let p0 = net.procs[0].public_key_share();
+    let p0 = net.procs[0].id();
     let vote = net.procs[0].propose(DummyProposal(42)).unwrap();
     net.broadcast(p0, vote);
     net.drain_queued_packets().unwrap();


### PR DESCRIPTION
The main change in this PR is to move from keep track of elders as a set of `public-key-shares` to a `PublicKeySet` polynomial.

This is in preparations to return aggregated `Signatures` upon nodes coming to agreement.

A happy side-effect is that we can now refer to elders by their DKG index, that is we can replace all instances of PublicKeyShare (48 bytes) with the corresponding index 1..7 (1 byte). This should be a nice reduction in vote sizes over the wire.