### PR TITLE
Sm sm broadcast when receiving new votes after termination

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -82,11 +82,7 @@ impl<T: Proposition> Consensus<T> {
 
     pub fn is_new_vote_from_voter(&self, signed_vote: &SignedVote<T>) -> bool {
         if let Some(previous_vote_from_voter) = self.votes.get(&signed_vote.voter) {
-            if signed_vote == previous_vote_from_voter {
-                false
-            } else {
-                signed_vote.supersedes(previous_vote_from_voter)
-            }
+            signed_vote.strict_supersedes(previous_vote_from_voter)
         } else {
             // if we have no votes from this voter, then it is new
             true

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -80,7 +80,7 @@ impl<T: Proposition> Consensus<T> {
         self.sign_vote(vote)
     }
 
-    pub fn contains_new_vote_from_voter(&self, signed_vote: &SignedVote<T>) -> bool {
+    pub fn is_new_vote_from_voter(&self, signed_vote: &SignedVote<T>) -> bool {
         if let Some(previous_vote_from_voter) = self.votes.get(&signed_vote.voter) {
             if signed_vote == previous_vote_from_voter {
                 false
@@ -115,7 +115,7 @@ impl<T: Proposition> Consensus<T> {
             .get_super_majority_over_super_majorities(&self.votes.values().cloned().collect())?
             .is_some();
 
-        if we_terminated && !they_terminated && self.contains_new_vote_from_voter(&signed_vote) {
+        if we_terminated && !they_terminated && self.is_new_vote_from_voter(&signed_vote) {
             info!("[MBR] Obtained new vote from {} after having already reached termination, sending out broadcast for others to catch up.", signed_vote.voter);
             let proof_sm_over_sm =
                 self.build_super_majority_vote(self.votes.values().cloned().collect(), gen)?;
@@ -381,7 +381,7 @@ mod tests {
     use rand::{prelude::StdRng, SeedableRng};
 
     #[test]
-    fn contains_new_vote_from_voter() {
+    fn test_is_new_vote_from_voter() {
         let mut rng = StdRng::from_seed([0u8; 32]);
         let elders_sk = SecretKeySet::random(10, &mut rng);
         let mut consensus = Consensus::from(
@@ -411,7 +411,7 @@ mod tests {
             .unwrap();
         // println!("new_vote: {:#?}", new_vote);
         // println!("our_vote: {:#?}", consensus.votes);
-        assert!(!consensus.contains_new_vote_from_voter(&new_vote));
+        assert!(!consensus.is_new_vote_from_voter(&new_vote));
 
         // try merge vote superseding existing vote
         let new_vote = consensus
@@ -424,7 +424,7 @@ mod tests {
             .unwrap();
         // println!("new_vote: {:#?}", new_vote);
         // println!("our_vote: {:#?}", consensus.votes);
-        assert!(consensus.contains_new_vote_from_voter(&new_vote));
+        assert!(consensus.is_new_vote_from_voter(&new_vote));
 
         // try bad vote not superseding existing
         let new_vote = consensus
@@ -435,6 +435,6 @@ mod tests {
             .unwrap();
         // println!("new_vote: {:#?}", new_vote);
         // println!("our_vote: {:#?}", consensus.votes);
-        assert!(!consensus.contains_new_vote_from_voter(&new_vote));
+        assert!(!consensus.is_new_vote_from_voter(&new_vote));
     }
 }

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -123,6 +123,16 @@ impl<T: Proposition> Consensus<T> {
             self.log_signed_vote(&signed_vote);
         }
 
+        if let Some(proposals) =
+            self.get_super_majority_over_super_majorities(&self.votes.values().cloned().collect())?
+        {
+            info!("[MBR] Detected super majority over super majorities: {proposals:?}");
+            return Ok(VoteResponse::Decided {
+                votes: self.votes.values().cloned().collect(),
+                proposals,
+            });
+        }
+
         if self.is_split_vote(&self.votes.values().cloned().collect()) {
             info!("[MBR] Detected split vote");
             let merge_vote = Vote {
@@ -143,16 +153,6 @@ impl<T: Proposition> Consensus<T> {
 
             info!("[MBR] Either we haven't voted or our previous vote didn't fully overlap, merge them.");
             return Ok(VoteResponse::Broadcast(self.cast_vote(signed_merge_vote)));
-        }
-
-        if let Some(proposals) =
-            self.get_super_majority_over_super_majorities(&self.votes.values().cloned().collect())?
-        {
-            info!("[MBR] Detected super majority over super majorities: {proposals:?}");
-            return Ok(VoteResponse::Decided {
-                votes: self.votes.values().cloned().collect(),
-                proposals,
-            });
         }
 
         if self.is_super_majority(&self.votes.values().cloned().collect()) {

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -115,15 +115,6 @@ impl<T: Proposition> Consensus<T> {
             info!("[MBR] Obtained new vote from {} after having already reached termination, sending out broadcast for others to catch up.", signed_vote.voter);
             let proof_sm_over_sm =
                 self.build_super_majority_vote(self.votes.values().cloned().collect(), gen)?;
-            assert!(self
-                .get_super_majority_over_super_majorities(
-                    &proof_sm_over_sm
-                        .unpack_votes()
-                        .into_iter()
-                        .map(|v| v.to_owned())
-                        .collect()
-                )?
-                .is_some());
             return Ok(VoteResponse::Broadcast(proof_sm_over_sm));
         }
 

--- a/src/vote.rs
+++ b/src/vote.rs
@@ -133,4 +133,8 @@ impl<T: Proposition> SignedVote<T> {
             }
         }
     }
+
+    pub fn strict_supersedes(&self, signed_vote: &Self) -> bool {
+        self != signed_vote && self.supersedes(signed_vote)
+    }
 }


### PR DESCRIPTION
When receiving a new proposal when we already reached termination, broadcast a SM vote with proof of SM/SM so others can catch up. 