### PR TITLE
Fault Detection

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -181,7 +181,7 @@ impl<T: Proposition> Consensus<T> {
         if !self.votes.contains_key(&self.id()) {
             let signed_vote = self.sign_vote(Vote {
                 gen,
-                ballot: signed_vote.vote.ballot,
+                ballot: Ballot::Merge(BTreeSet::from_iter([signed_vote])),
                 faults: self.faults(),
             })?;
             return Ok(VoteResponse::Broadcast(self.cast_vote(signed_vote)));

--- a/src/error.rs
+++ b/src/error.rs
@@ -51,6 +51,8 @@ pub enum Error {
     SuperMajorityProposalsDoesNotMatchVoteProposals,
     #[error("Blsttc Error {0}")]
     Blsttc(#[from] blsttc::error::Error),
+    #[error("Client attempted a faulty proposal")]
+    AttemptedFaultyProposal,
 
     #[cfg(feature = "ed25519")]
     #[error("Ed25519 Error {0}")]

--- a/src/fault.rs
+++ b/src/fault.rs
@@ -1,0 +1,67 @@
+use blsttc::PublicKeySet;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::{NodeId, Proposition, SignedVote};
+
+#[derive(Debug, Error)]
+pub enum FaultError {
+    #[error("The claimed ChangedVote fault is dealing with votes from different voters")]
+    ChangedVoteFaultIsFromDifferentVoters,
+    #[error("The claimed ChangedVote fault is not actually incompatible votes")]
+    ChangedVoteIsNotActuallyChanged,
+    #[error("FaultProof used a vote that was improperly signed")]
+    AccusedAnImproperlySignedVote,
+    #[error("InvalidFaultProof was actually valid")]
+    AccusedVoteOfInvalidFaultButAllFaultsAreValid,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum Fault<T: Proposition> {
+    ChangedVote { a: SignedVote<T>, b: SignedVote<T> },
+    InvalidFault { signed_vote: SignedVote<T> },
+}
+
+impl<T: Proposition> Fault<T> {
+    pub fn voter_at_fault(&self) -> NodeId {
+        match self {
+            Fault::ChangedVote { a, .. } => a.voter,
+            Fault::InvalidFault { signed_vote } => signed_vote.voter,
+        }
+    }
+
+    pub fn validate(&self, voters: &PublicKeySet) -> std::result::Result<(), FaultError> {
+        match self {
+            Self::ChangedVote { a, b } => {
+                a.validate_signature(voters)
+                    .map_err(|_| FaultError::AccusedAnImproperlySignedVote)?;
+                b.validate_signature(voters)
+                    .map_err(|_| FaultError::AccusedAnImproperlySignedVote)?;
+                if a.voter != b.voter {
+                    return Err(FaultError::ChangedVoteFaultIsFromDifferentVoters);
+                }
+                if a.supersedes(b) || b.supersedes(a) {
+                    return Err(FaultError::ChangedVoteIsNotActuallyChanged);
+                }
+                Ok(())
+            }
+            Self::InvalidFault { signed_vote } => {
+                signed_vote
+                    .validate_signature(voters)
+                    .map_err(|_| FaultError::AccusedAnImproperlySignedVote)?;
+
+                let all_faults_are_valid = signed_vote
+                    .vote
+                    .faults
+                    .iter()
+                    .all(|f| f.validate(voters).is_ok());
+
+                if signed_vote.vote.faults.is_empty() || all_faults_are_valid {
+                    Err(FaultError::AccusedVoteOfInvalidFaultButAllFaultsAreValid)
+                } else {
+                    Ok(())
+                }
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub mod ed25519;
 use blsttc::{PublicKeySet, SignatureShare};
 use serde::Serialize;
 
-pub use crate::consensus::Consensus;
+pub use crate::consensus::{Consensus, Decision, VoteResponse};
 pub use crate::fault::{Fault, FaultError};
 pub use crate::sn_handover::{Handover, UniqueSectionId};
 pub use crate::sn_membership::{Generation, Membership, Reconfig};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod consensus;
+pub mod fault;
 pub mod sn_handover;
 pub mod sn_membership;
 pub mod vote;
@@ -10,7 +11,11 @@ pub mod bad_crypto;
 #[cfg(feature = "ed25519")]
 pub mod ed25519;
 
+use blsttc::{PublicKeySet, SignatureShare};
+use serde::Serialize;
+
 pub use crate::consensus::Consensus;
+pub use crate::fault::{Fault, FaultError};
 pub use crate::sn_handover::{Handover, UniqueSectionId};
 pub use crate::sn_membership::{Generation, Membership, Reconfig};
 pub use crate::vote::{Ballot, Proposition, SignedVote, Vote};
@@ -26,3 +31,18 @@ pub mod error;
 pub use crate::error::Error;
 pub type Result<T> = std::result::Result<T, Error>;
 pub type NodeId = u8;
+
+pub fn verify_sig_share<M: Serialize>(
+    msg: &M,
+    sig: &SignatureShare,
+    voter: NodeId,
+    voters: &PublicKeySet,
+) -> Result<()> {
+    let public_key = voters.public_key_share(voter as u64);
+    let msg_bytes = bincode::serialize(msg)?;
+    if public_key.verify(sig, msg_bytes) {
+        Ok(())
+    } else {
+        Err(Error::InvalidElderSignature)
+    }
+}

--- a/src/sn_handover.rs
+++ b/src/sn_handover.rs
@@ -33,9 +33,13 @@ impl<T: Proposition> Handover<T> {
         let vote = Vote {
             gen: self.gen,
             ballot: Ballot::Propose(proposal),
+            faults: self.consensus.faults(),
         };
         let signed_vote = self.sign_vote(vote)?;
         self.validate_signed_vote(&signed_vote)?;
+        self.consensus
+            .detect_byzantine_voters(&signed_vote)
+            .map_err(|_| Error::AttemptedFaultyProposal)?;
         Ok(self.cast_vote(signed_vote))
     }
 

--- a/src/sn_handover.rs
+++ b/src/sn_handover.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use blsttc::{PublicKeySet, SecretKeyShare};
+use blsttc::{PublicKeySet, SecretKeyShare, Signature};
 use core::fmt::Debug;
 use log::info;
 
@@ -50,16 +50,10 @@ impl<T: Proposition> Handover<T> {
         self.consensus.votes.values().cloned().collect()
     }
 
-    pub fn resolve_votes(&self, votes: &BTreeSet<SignedVote<T>>) -> Option<T> {
-        let (winning_proposals, _) = self
-            .count_votes(votes)
-            .into_iter()
-            .max_by_key(|(_, count)| *count)
-            .unwrap_or_default();
-
+    pub fn resolve_votes<'a>(&self, proposals: &'a BTreeMap<T, Signature>) -> Option<&'a T> {
         // we need to choose one deterministically
         // proposals are comparable because they impl Ord so we arbitrarily pick the max
-        winning_proposals.into_iter().max()
+        proposals.keys().max()
     }
 
     pub fn id(&self) -> NodeId {

--- a/src/sn_membership.rs
+++ b/src/sn_membership.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::consensus::{Consensus, VoteResponse};
 use crate::vote::{Ballot, Proposition, SignedVote, Vote};
-use crate::{Error, Fault, NodeId, Result};
+use crate::{Decision, Error, Fault, NodeId, Result};
 
 const SOFT_MAX_MEMBERS: usize = 7;
 pub type Generation = u64;
@@ -171,11 +171,11 @@ impl<T: Proposition> Membership<T> {
             VoteResponse::Broadcast(vote) => {
                 self.pending_gen = vote.vote.gen;
             }
-            VoteResponse::Decided {
+            VoteResponse::Decided(Decision {
                 votes,
                 proposals,
                 faults,
-            } => {
+            }) => {
                 self.history.insert(
                     self.pending_gen,
                     HistoryEntry {

--- a/src/sn_membership.rs
+++ b/src/sn_membership.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::consensus::{Consensus, VoteResponse};
 use crate::vote::{Ballot, Proposition, SignedVote, Vote};
-use crate::{Error, NodeId, Result};
+use crate::{Error, Fault, NodeId, Result};
 
 const SOFT_MAX_MEMBERS: usize = 7;
 pub type Generation = u64;
@@ -16,6 +16,7 @@ pub type Generation = u64;
 pub struct HistoryEntry<T: Proposition> {
     pub votes: BTreeSet<SignedVote<Reconfig<T>>>,
     pub proposals: BTreeMap<Reconfig<T>, Signature>,
+    pub faults: BTreeSet<Fault<Reconfig<T>>>,
 }
 
 #[derive(Debug)]
@@ -122,9 +123,13 @@ impl<T: Proposition> Membership<T> {
         let vote = Vote {
             gen: self.gen + 1,
             ballot: Ballot::Propose(reconfig),
+            faults: self.consensus.faults(),
         };
         let signed_vote = self.sign_vote(vote)?;
         self.validate_signed_vote(&signed_vote)?;
+        self.consensus
+            .detect_byzantine_voters(&signed_vote)
+            .map_err(|_| Error::AttemptedFaultyProposal)?;
         Ok(self.cast_vote(signed_vote))
     }
 
@@ -166,12 +171,17 @@ impl<T: Proposition> Membership<T> {
             VoteResponse::Broadcast(vote) => {
                 self.pending_gen = vote.vote.gen;
             }
-            VoteResponse::Decided { votes, proposals } => {
+            VoteResponse::Decided {
+                votes,
+                proposals,
+                faults,
+            } => {
                 self.history.insert(
                     self.pending_gen,
                     HistoryEntry {
                         votes: votes.clone(),
                         proposals: proposals.clone(),
+                        faults: faults.clone(),
                     },
                 );
                 self.gen = self.pending_gen;

--- a/src/vote.rs
+++ b/src/vote.rs
@@ -35,7 +35,7 @@ impl<T: Proposition> Debug for Ballot<T> {
     }
 }
 
-fn simplify_votes<T: Proposition>(
+pub fn simplify_votes<T: Proposition>(
     signed_votes: &BTreeSet<SignedVote<T>>,
 ) -> BTreeSet<SignedVote<T>> {
     let mut simpler_votes = BTreeSet::new();

--- a/src/vote.rs
+++ b/src/vote.rs
@@ -1,11 +1,11 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use blsttc::SignatureShare;
+use blsttc::{PublicKeySet, SignatureShare};
 use core::fmt::Debug;
 use serde::{Deserialize, Serialize};
 
 use crate::sn_membership::Generation;
-use crate::NodeId;
+use crate::{Fault, NodeId, Result};
 
 pub trait Proposition: Ord + Clone + Debug + Serialize {}
 impl<T: Ord + Clone + Debug + Serialize> Proposition for T {}
@@ -52,7 +52,28 @@ fn simplify_votes<T: Proposition>(
     simpler_votes
 }
 
+pub fn proposals<T: Proposition>(
+    votes: &BTreeSet<SignedVote<T>>,
+    known_faulty: &BTreeSet<NodeId>,
+) -> BTreeSet<T> {
+    BTreeSet::from_iter(
+        votes
+            .iter()
+            .flat_map(SignedVote::unpack_votes)
+            .filter(|v| !known_faulty.contains(&v.voter))
+            .filter_map(|v| v.vote.ballot.as_proposal())
+            .cloned(),
+    )
+}
+
 impl<T: Proposition> Ballot<T> {
+    pub fn as_proposal(&self) -> Option<&T> {
+        match &self {
+            Ballot::Propose(p) => Some(p),
+            _ => None,
+        }
+    }
+
     #[must_use]
     pub fn simplify(&self) -> Self {
         match &self {
@@ -70,11 +91,17 @@ impl<T: Proposition> Ballot<T> {
 pub struct Vote<T: Proposition> {
     pub gen: Generation,
     pub ballot: Ballot<T>,
+    pub faults: BTreeSet<Fault<T>>,
 }
 
 impl<T: Proposition> Debug for Vote<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "G{}-{:?}", self.gen, self.ballot)
+        write!(f, "G{}-{:?}", self.gen, self.ballot)?;
+
+        if !self.faults.is_empty() {
+            write!(f, "-F{:?}", self.faults)?;
+        }
+        Ok(())
     }
 }
 
@@ -83,12 +110,24 @@ impl<T: Proposition> Vote<T> {
         matches!(self.ballot, Ballot::SuperMajority { .. })
     }
 
+    pub fn to_bytes(&self) -> Result<Vec<u8>> {
+        Ok(bincode::serialize(&self)?)
+    }
+
+    pub fn known_faulty(&self) -> BTreeSet<NodeId> {
+        BTreeSet::from_iter(self.faults.iter().map(Fault::voter_at_fault))
+    }
+
     pub fn proposals(&self) -> BTreeSet<T> {
+        self.proposals_with_known_faults(&self.known_faulty())
+    }
+
+    pub fn proposals_with_known_faults(&self, known_faulty: &BTreeSet<NodeId>) -> BTreeSet<T> {
         match &self.ballot {
             Ballot::Propose(proposal) => BTreeSet::from_iter([proposal.clone()]),
             Ballot::Merge(votes) | Ballot::SuperMajority { votes, .. } => {
                 // TAI: use proposals instead of recursing on SuperMajority?
-                BTreeSet::from_iter(votes.iter().flat_map(SignedVote::proposals))
+                proposals(votes, known_faulty)
             }
         }
     }
@@ -108,6 +147,10 @@ impl<T: Proposition> Debug for SignedVote<T> {
 }
 
 impl<T: Proposition> SignedVote<T> {
+    pub fn validate_signature(&self, voters: &PublicKeySet) -> Result<()> {
+        crate::verify_sig_share(&self.vote, &self.sig, self.voter, voters)
+    }
+
     pub fn unpack_votes(&self) -> BTreeSet<&Self> {
         match &self.vote.ballot {
             Ballot::Propose(_) => BTreeSet::from_iter([self]),
@@ -121,14 +164,20 @@ impl<T: Proposition> SignedVote<T> {
         self.vote.proposals()
     }
 
-    pub fn supersedes(&self, signed_vote: &Self) -> bool {
-        if self == signed_vote {
+    pub fn supersedes(&self, other: &Self) -> bool {
+        let our_known_faulty = self.vote.known_faulty();
+        let other_known_faulty = other.vote.known_faulty();
+
+        if (&self.voter, self.vote.gen, &self.vote.ballot)
+            == (&other.voter, other.vote.gen, &other.vote.ballot)
+            && our_known_faulty.is_superset(&other_known_faulty)
+        {
             true
         } else {
             match &self.vote.ballot {
-                Ballot::Propose(_) => false,
+                Ballot::Propose(_) => false, // equality is already checked above
                 Ballot::Merge(votes) | Ballot::SuperMajority { votes, .. } => {
-                    votes.iter().any(|v| v.supersedes(signed_vote))
+                    votes.iter().any(|v| v.supersedes(other))
                 }
             }
         }

--- a/tests/handover_net.rs
+++ b/tests/handover_net.rs
@@ -48,14 +48,11 @@ impl Net {
     }
 
     pub fn consensus_value(&self, proc: usize) -> Option<u8> {
-        let all_votes = self.procs[proc]
+        self.procs[proc]
             .consensus
-            .votes
-            .iter()
-            .map(|(_voter, vote)| vote)
-            .cloned()
-            .collect();
-        self.procs[proc].resolve_votes(&all_votes)
+            .decision
+            .as_ref()
+            .and_then(|decision| self.procs[proc].resolve_votes(&decision.proposals).cloned())
     }
 
     /// Pick a random public key from the set of procs

--- a/tests/handover_net.rs
+++ b/tests/handover_net.rs
@@ -131,6 +131,7 @@ impl Net {
         let vote = Vote {
             gen: rng.gen::<u64>() % 7,
             ballot: self.gen_ballot(recursion, faulty_nodes, rng),
+            faults: Default::default(),
         };
 
         SignedVote {

--- a/tests/membership_net.rs
+++ b/tests/membership_net.rs
@@ -115,6 +115,7 @@ impl Net {
         let vote = Vote {
             gen: rng.gen::<u64>() % 7,
             ballot: self.gen_ballot(recursion, faulty_nodes, rng),
+            faults: Default::default(),
         };
 
         SignedVote {

--- a/tests/sn_handover.rs
+++ b/tests/sn_handover.rs
@@ -44,19 +44,13 @@ fn test_handover_one_faulty_node_and_many_packet_drops() {
     // since everyone agreed already they can't change their votes
     // they have reached consensus
     let first_voters_value = net.consensus_value(0);
-    for i in 0..4 {
+    for i in 0..5 {
         let decision = net.consensus_value(i);
         println!("[TEST] checking voter {i}'s consensus value: {decision:?}");
         assert_eq!(decision, first_voters_value);
     }
 
-    // segregated_elder could be stuck because he can't accept the SM because it's poisoned
-    // check that segregated_elder was still able to reach consensus
-    println!(
-        "[TEST] checking voter 4's consensus value: {:?}",
-        net.consensus_value(4)
-    );
-    assert_eq!(net.consensus_value(4), first_voters_value);
+    assert_eq!(first_voters_value, Some(1));
 }
 
 #[test]

--- a/tests/sn_handover.rs
+++ b/tests/sn_handover.rs
@@ -5,12 +5,11 @@ mod handover_net;
 use handover_net::{DummyProposal, Net, Packet};
 use sn_membership::{Ballot, Error, Handover, Result, SignedVote, Vote};
 
-#[ignore] // TODO enable after we did fault detection
 #[test]
 fn test_handover_one_faulty_node_and_many_packet_drops() {
     // make network of 5 elders with one segregated (his network is really bad)
     let mut rng = StdRng::from_seed([0u8; 32]);
-    let mut net = Net::with_procs(4, 5, &mut rng);
+    let mut net = Net::with_procs(3, 5, &mut rng);
     let segregated_elder = net.procs.pop().unwrap();
 
     // p0 is a bad node and the network is really bad for the segregated elder so he's not connected yet
@@ -37,6 +36,10 @@ fn test_handover_one_faulty_node_and_many_packet_drops() {
         vote: bad_vote,
     }]);
     net.procs.push(segregated_elder);
+    net.drain_queued_packets().unwrap();
+
+    net.generate_msc("handover_one_faulty_node_and_many_packet_drops.msc")
+        .unwrap();
 
     // since everyone agreed already they can't change their votes
     // they have reached consensus
@@ -223,7 +226,7 @@ fn test_handover_round_robin_split_vote() -> eyre::Result<()> {
         net.drain_queued_packets()?;
 
         // generate msc file
-        net.generate_msc(&format!("round_robin_split_vote_{}.msc", nprocs))?;
+        net.generate_msc(&format!("handover_round_robin_split_vote_{}.msc", nprocs))?;
 
         // make sure they all reach the same conclusion
         let max_proposed_value = nprocs - 1;
@@ -254,7 +257,7 @@ fn test_handover_simple_proposal() {
     net.drain_queued_packets().unwrap();
     assert!(net.packets.is_empty());
 
-    net.generate_msc("simple_join.msc").unwrap();
+    net.generate_msc("handover_simple_join.msc").unwrap();
 
     // make sure they all reach the same conclusion
     let first_voters_value = net.consensus_value(0);


### PR DESCRIPTION
`test_membership_bft_consensus_qc2` Demonstrating honest node failure to terminate when a faulty node lies about vote.

We fix this issue by introducing fault detection: 
- All votes now include all faults seen by the voter
- When resolving the set of proposals in a vote, we filter out proposals originating from faulty voters.

Another change in this PR is in how nodes adopt each others proposals, previously a node would copy the ballot and claim it as it's own, now we wrap the vote in a merge. This is done to give credit for why each node decided to adopt a proposal, If the source a proposal is eventually seen to be faulty, then we can discard the proposal entirely.

This was not possible when nodes were copying ballots, since this broke the causal link, we didn't know who gave this node the idea to vote with this ballot.

Not all classes of faults have been implemented yet, I've noted them as TODO's in the code, but I'll turn them in to Issues before merging