### PR TITLE
Bft consensus qc3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,7 @@ edition = "2021"
 [dependencies]
 rand = "0.7.3"
 bincode = "1.2.1"
-hex = "0.4.2"
 thiserror = "1.0"
-signature = "1.3.0"
 log = "0.4.13"
 
   [dependencies.serde]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,4 @@ debug = true
 eyre = "0.6.5"
 quickcheck = "1"
 quickcheck_macros = "1"
+env_logger = "0.8"

--- a/quickcheck_forever.sh
+++ b/quickcheck_forever.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export QUICKCHECK_TESTS=10000000
+export QUICKCHECK_TESTS=100
 
 while true
 do

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -18,13 +18,14 @@ pub struct Consensus<T: Proposition> {
     pub decision: Option<Decision<T>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Decision<T: Proposition> {
     pub votes: BTreeSet<SignedVote<T>>,
     pub proposals: BTreeMap<T, Signature>,
     pub faults: BTreeSet<Fault<T>>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VoteResponse<T: Proposition> {
     WaitingForMoreVotes,
     Broadcast(SignedVote<T>),
@@ -271,7 +272,7 @@ impl<T: Proposition> Consensus<T> {
         let voters = BTreeSet::from_iter(votes.iter().map(|v| v.voter));
         let remaining_voters = self.n_elders - voters.len();
 
-        // give the remaining votes to the proposals with the most votes.
+        // suppose the remaining votes go to the proposals with the most votes.
         let predicted_votes = most_votes + remaining_voters;
 
         voters.len() > self.elders.threshold() && predicted_votes <= self.elders.threshold()

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -168,8 +168,9 @@ impl<T: Proposition> Consensus<T> {
                 "[MBR-{}] Detected super majority over super majorities: {proposals:?}",
                 self.id()
             );
+            let votes = crate::vote::simplify_votes(&self.votes.values().cloned().collect());
             let decision = Decision {
-                votes: self.votes.values().cloned().collect(),
+                votes,
                 proposals,
                 faults: self.faults(),
             };

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -96,8 +96,9 @@ impl<T: Proposition> Consensus<T> {
     /// Handles a signed vote
     /// Returns the vote we cast and the reached consensus vote in case consensus was reached
     pub fn handle_signed_vote(&mut self, signed_vote: SignedVote<T>) -> Result<VoteResponse<T>> {
+        info!("[MBR-{}] handling vote {:?}", self.id(), signed_vote);
         if let Err(faults) = self.detect_byzantine_voters(&signed_vote) {
-            println!("[MBR-{}] Found faults {:?}", self.id(), faults);
+            info!("[MBR-{}] Found faults {:?}", self.id(), faults);
             self.faults.extend(faults);
         }
 
@@ -107,7 +108,7 @@ impl<T: Proposition> Consensus<T> {
 
         if let Some(decision) = self.decision.clone() {
             if their_decision.is_none() && self.is_new_vote_from_voter(&signed_vote) {
-                println!(
+                info!(
                     "[MBR-{}] We've already terminated, responding with decision",
                     self.id()
                 );
@@ -124,7 +125,7 @@ impl<T: Proposition> Consensus<T> {
             // This case is here to handle situations where this node has recieved
             // a faulty vote previously that is preventing it from accepting a network
             // decision using the sm_over_sm logic below.
-            println!(
+            info!(
                 "[MBR-{}] They terminated but we haven't yet, accepting decision",
                 self.id()
             );
@@ -228,6 +229,7 @@ impl<T: Proposition> Consensus<T> {
             return Ok(VoteResponse::Broadcast(self.cast_vote(signed_vote)));
         }
 
+        info!("[MBR-{}] waiting for more votes", self.id());
         Ok(VoteResponse::WaitingForMoreVotes)
     }
 

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -153,7 +153,7 @@ impl<T: Proposition> Consensus<T> {
             let decision = Decision {
                 votes,
                 proposals,
-                faults: self.faults(),
+                faults: signed_vote.vote.faults.clone(),
             };
             self.decision = Some(decision.clone());
             return Ok(VoteResponse::Decided(decision));

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -29,7 +29,6 @@ pub struct Decision<T: Proposition> {
 pub enum VoteResponse<T: Proposition> {
     WaitingForMoreVotes,
     Broadcast(SignedVote<T>),
-    Decided(Decision<T>),
 }
 
 impl<T: Proposition> Consensus<T> {
@@ -155,8 +154,8 @@ impl<T: Proposition> Consensus<T> {
                 proposals,
                 faults: signed_vote.vote.faults.clone(),
             };
-            self.decision = Some(decision.clone());
-            return Ok(VoteResponse::Decided(decision));
+            self.decision = Some(decision);
+            return Ok(VoteResponse::WaitingForMoreVotes);
         }
 
         self.log_signed_vote(&signed_vote);
@@ -174,8 +173,8 @@ impl<T: Proposition> Consensus<T> {
                 proposals,
                 faults: self.faults(),
             };
-            self.decision = Some(decision.clone());
-            return Ok(VoteResponse::Decided(decision));
+            self.decision = Some(decision);
+            return Ok(VoteResponse::WaitingForMoreVotes);
         }
 
         if self.is_split_vote(&self.votes.values().cloned().collect()) {

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -101,6 +101,10 @@ impl<T: Proposition> Consensus<T> {
             info!("[MBR-{}] Found faults {:?}", self.id(), faults);
             self.faults.extend(faults);
         }
+        if self.faults.contains_key(&signed_vote.voter) {
+            info!("[MBR-{}] dropping vote from faulty voter", self.id());
+            return Ok(VoteResponse::WaitingForMoreVotes);
+        }
 
         let their_decision = self.get_super_majority_over_super_majorities(
             &signed_vote.unpack_votes().into_iter().cloned().collect(),

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -70,7 +70,7 @@ impl<T: Proposition> Consensus<T> {
                 .into_iter()
                 .map(|p| {
                     let sig = self.sign(&p)?;
-                    Ok((p, (self.secret_key.0, sig)))
+                    Ok((p, (self.id(), sig)))
                 })
                 .collect::<Result<_>>()?;
         let vote = Vote {
@@ -267,7 +267,7 @@ impl<T: Proposition> Consensus<T> {
 
     pub fn sign_vote(&self, vote: Vote<T>) -> Result<SignedVote<T>> {
         Ok(SignedVote {
-            voter: self.secret_key.0,
+            voter: self.id(),
             sig: self.sign(&vote)?,
             vote,
         })

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -260,7 +260,7 @@ impl<T: Proposition> Consensus<T> {
 
     fn is_split_vote(&self, count: &VoteCount<T>) -> bool {
         let most_votes = count
-            .candidates_with_most_votes()
+            .candidate_with_most_votes()
             .map(|(_, c)| c)
             .unwrap_or(0);
         let remaining_voters = self.n_elders - count.voters.len();
@@ -273,7 +273,7 @@ impl<T: Proposition> Consensus<T> {
 
     pub fn is_super_majority(&self, count: &VoteCount<T>) -> bool {
         let most_votes = count
-            .candidates_with_most_votes()
+            .candidate_with_most_votes()
             .map(|(_, c)| c)
             .unwrap_or_default();
 
@@ -281,7 +281,7 @@ impl<T: Proposition> Consensus<T> {
     }
 
     fn get_decision(&self, vote_count: &VoteCount<T>) -> Result<Option<BTreeMap<T, Signature>>> {
-        if let Some((_candidate, shares_by_voter)) = vote_count.super_majorities_with_most_votes() {
+        if let Some((_candidate, shares_by_voter)) = vote_count.super_majority_with_most_votes() {
             if shares_by_voter.len() > self.elders.threshold() {
                 let mut proposal_sigs: BTreeMap<T, BTreeSet<(u64, SignatureShare)>> =
                     Default::default();

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use core::fmt::Debug;
 use thiserror::Error;
 
-use crate::{Generation, UniqueSectionId};
+use crate::Generation;
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -24,12 +24,6 @@ pub enum Error {
     VoteForBadGeneration {
         vote_gen: Generation,
         gen: Generation,
-        pending_gen: Generation,
-    },
-    #[error("Vote received has a different unique section id: vote gen {vote_gen} != {gen}")]
-    VoteWithInvalidUniqueSectionId {
-        vote_gen: UniqueSectionId,
-        gen: UniqueSectionId,
     },
     #[error("The voter is not an elder")]
     NotElder,

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,8 +20,8 @@ pub enum Error {
         child_gen: Generation,
         merge_gen: Generation,
     },
-    #[error("A vote is always for the next generation: vote gen {vote_gen} != {gen} + 1, pending gen: {pending_gen}")]
-    VoteNotForNextGeneration {
+    #[error("A vote must be tagged with a generation between 1..=(gen={gen} + 1): vote gen = {vote_gen}, gen: {gen}")]
+    VoteForBadGeneration {
         vote_gen: Generation,
         gen: Generation,
         pending_gen: Generation,

--- a/src/sn_handover.rs
+++ b/src/sn_handover.rs
@@ -84,7 +84,7 @@ impl<T: Proposition> Handover<T> {
 
     pub fn validate_signed_vote(&self, signed_vote: &SignedVote<T>) -> Result<()> {
         if signed_vote.vote.gen != self.gen {
-            return Err(Error::VoteWithInvalidUniqueSectionId {
+            return Err(Error::VoteForBadGeneration {
                 vote_gen: signed_vote.vote.gen,
                 gen: self.gen,
             });

--- a/src/sn_handover.rs
+++ b/src/sn_handover.rs
@@ -40,7 +40,7 @@ impl<T: Proposition> Handover<T> {
         self.consensus
             .detect_byzantine_voters(&signed_vote)
             .map_err(|_| Error::AttemptedFaultyProposal)?;
-        Ok(self.cast_vote(signed_vote))
+        self.cast_vote(&signed_vote)
     }
 
     // Get someone up to speed on our view of the current votes
@@ -79,13 +79,8 @@ impl<T: Proposition> Handover<T> {
         self.consensus.sign_vote(vote)
     }
 
-    pub fn cast_vote(&mut self, signed_vote: SignedVote<T>) -> SignedVote<T> {
-        self.log_signed_vote(&signed_vote);
-        signed_vote
-    }
-
-    fn log_signed_vote(&mut self, signed_vote: &SignedVote<T>) {
-        self.consensus.log_signed_vote(signed_vote);
+    pub fn cast_vote(&mut self, signed_vote: &SignedVote<T>) -> Result<SignedVote<T>> {
+        self.consensus.cast_vote(signed_vote)
     }
 
     pub fn count_votes(&self, votes: &BTreeSet<SignedVote<T>>) -> BTreeMap<BTreeSet<T>, usize> {

--- a/src/sn_handover.rs
+++ b/src/sn_handover.rs
@@ -70,7 +70,6 @@ impl<T: Proposition> Handover<T> {
 
         match vote_response {
             VoteResponse::Broadcast(vote) => Ok(Some(vote)),
-            VoteResponse::Decided { .. } => Ok(None),
             VoteResponse::WaitingForMoreVotes => Ok(None),
         }
     }

--- a/src/sn_handover.rs
+++ b/src/sn_handover.rs
@@ -66,7 +66,7 @@ impl<T: Proposition> Handover<T> {
     ) -> Result<Option<SignedVote<T>>> {
         self.validate_signed_vote(&signed_vote)?;
 
-        let vote_response = self.consensus.handle_signed_vote(signed_vote, self.gen)?;
+        let vote_response = self.consensus.handle_signed_vote(signed_vote)?;
 
         match vote_response {
             VoteResponse::Broadcast(vote) => Ok(Some(vote)),

--- a/src/sn_handover.rs
+++ b/src/sn_handover.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
 use blsttc::{PublicKeySet, SecretKeyShare, Signature};
 use core::fmt::Debug;
@@ -80,10 +80,6 @@ impl<T: Proposition> Handover<T> {
 
     pub fn cast_vote(&mut self, signed_vote: &SignedVote<T>) -> Result<SignedVote<T>> {
         self.consensus.cast_vote(signed_vote)
-    }
-
-    pub fn count_votes(&self, votes: &BTreeSet<SignedVote<T>>) -> BTreeMap<BTreeSet<T>, usize> {
-        self.consensus.count_votes(votes)
     }
 
     pub fn validate_signed_vote(&self, signed_vote: &SignedVote<T>) -> Result<()> {

--- a/src/sn_membership.rs
+++ b/src/sn_membership.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::consensus::{Consensus, VoteResponse};
 use crate::vote::{Ballot, Proposition, SignedVote, Vote};
-use crate::{Error, Fault, NodeId, Result};
+use crate::{Error, NodeId, Result};
 
 const SOFT_MAX_MEMBERS: usize = 7;
 pub type Generation = u64;
@@ -156,11 +156,7 @@ impl<T: Proposition> Membership<T> {
             .filter(|(gen, _)| **gen > from_gen)
             .filter_map(|(gen, c)| c.decision.clone().map(|d| (gen, c, d)))
             .map(|(gen, c, decision)| {
-                c.build_super_majority_vote(
-                    decision.votes.clone(),
-                    *gen,
-                    &BTreeSet::from_iter(decision.faults.iter().map(Fault::voter_at_fault)),
-                )
+                c.build_super_majority_vote(decision.votes, decision.faults, *gen)
             })
             .collect::<Result<Vec<_>>>()?;
 

--- a/src/sn_membership.rs
+++ b/src/sn_membership.rs
@@ -130,7 +130,7 @@ impl<T: Proposition> Membership<T> {
         self.consensus
             .detect_byzantine_voters(&signed_vote)
             .map_err(|_| Error::AttemptedFaultyProposal)?;
-        Ok(self.cast_vote(signed_vote))
+        self.cast_vote(signed_vote)
     }
 
     pub fn anti_entropy(&self, from_gen: Generation) -> Result<Vec<SignedVote<Reconfig<T>>>> {
@@ -198,14 +198,13 @@ impl<T: Proposition> Membership<T> {
         self.consensus.sign_vote(vote)
     }
 
-    pub fn cast_vote(&mut self, signed_vote: SignedVote<Reconfig<T>>) -> SignedVote<Reconfig<T>> {
-        self.log_signed_vote(&signed_vote);
-        signed_vote
-    }
-
-    fn log_signed_vote(&mut self, signed_vote: &SignedVote<Reconfig<T>>) {
+    pub fn cast_vote(
+        &mut self,
+        signed_vote: SignedVote<Reconfig<T>>,
+    ) -> Result<SignedVote<Reconfig<T>>> {
+        self.consensus_mut().cast_vote(&signed_vote)?;
         self.pending_gen = signed_vote.vote.gen;
-        self.consensus.log_signed_vote(signed_vote);
+        Ok(signed_vote)
     }
 
     pub fn count_votes(

--- a/src/sn_membership.rs
+++ b/src/sn_membership.rs
@@ -217,7 +217,7 @@ impl<T: Proposition> Membership<T> {
 
     pub fn validate_signed_vote(&self, signed_vote: &SignedVote<Reconfig<T>>) -> Result<()> {
         if signed_vote.vote.gen != self.gen + 1 {
-            return Err(Error::VoteNotForNextGeneration {
+            return Err(Error::VoteForBadGeneration {
                 vote_gen: signed_vote.vote.gen,
                 gen: self.gen,
                 pending_gen: self.pending_gen,

--- a/src/sn_membership.rs
+++ b/src/sn_membership.rs
@@ -164,7 +164,6 @@ impl<T: Proposition> Membership<T> {
         signed_vote: SignedVote<Reconfig<T>>,
     ) -> Result<VoteResponse<Reconfig<T>>> {
         self.validate_signed_vote(&signed_vote)?;
-        self.log_signed_vote(&signed_vote);
 
         let vote_response = self.consensus.handle_signed_vote(signed_vote)?;
 

--- a/src/sn_membership.rs
+++ b/src/sn_membership.rs
@@ -7,19 +7,18 @@ use serde::{Deserialize, Serialize};
 
 use crate::consensus::{Consensus, VoteResponse};
 use crate::vote::{Ballot, Proposition, SignedVote, Vote};
-use crate::{Decision, Error, Fault, NodeId, Result};
+use crate::{Error, Fault, NodeId, Result};
 
 const SOFT_MAX_MEMBERS: usize = 7;
 pub type Generation = u64;
 
 #[derive(Debug)]
 pub struct Membership<T: Proposition> {
-    pub consensus: BTreeMap<Generation, Consensus<Reconfig<T>>>,
-    // TODO: we need faulty elder detection
-    // pub faulty_elders: BTreeMap<PublicKeyShare, BTreeSet<SignedVote<Reconfig<T>>>>,
+    pub consensus: Consensus<Reconfig<T>>,
     pub gen: Generation,
     pub pending_gen: Generation,
-    pub forced_reconfigs: BTreeMap<Generation, BTreeSet<Reconfig<T>>>, // TODO: change to bootstrap members
+    pub forced_reconfigs: BTreeMap<Generation, BTreeSet<Reconfig<T>>>,
+    pub history: BTreeMap<Generation, Consensus<Reconfig<T>>>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -52,28 +51,29 @@ impl<T: Proposition> Membership<T> {
         elders: PublicKeySet,
         n_elders: usize,
     ) -> Self {
-        Membership::<T> {
-            consensus: BTreeMap::from_iter([(1, Consensus::from(secret_key, elders, n_elders))]),
+        Membership {
+            consensus: Consensus::from(secret_key, elders, n_elders),
             gen: 0,
             pending_gen: 0,
             forced_reconfigs: Default::default(),
+            history: BTreeMap::default(),
         }
     }
 
     pub fn consensus_at_gen(&self, gen: Generation) -> Option<&Consensus<Reconfig<T>>> {
-        self.consensus.get(&gen)
+        if gen == self.gen + 1 {
+            Some(&self.consensus)
+        } else {
+            self.history.get(&gen)
+        }
     }
 
     pub fn consensus_at_gen_mut(&mut self, gen: Generation) -> Option<&mut Consensus<Reconfig<T>>> {
-        self.consensus.get_mut(&gen)
-    }
-
-    pub fn consensus(&self) -> &Consensus<Reconfig<T>> {
-        self.consensus_at_gen(self.gen + 1).unwrap()
-    }
-
-    pub fn consensus_mut(&mut self) -> &mut Consensus<Reconfig<T>> {
-        self.consensus_at_gen_mut(self.gen + 1).unwrap()
+        if gen == self.gen + 1 {
+            Some(&mut self.consensus)
+        } else {
+            self.history.get_mut(&gen)
+        }
     }
 
     pub fn force_join(&mut self, actor: T) {
@@ -106,7 +106,7 @@ impl<T: Proposition> Membership<T> {
             return Ok(members);
         }
 
-        for (history_gen, consensus) in self.consensus.iter() {
+        for (history_gen, consensus) in self.history.iter() {
             self.forced_reconfigs
                 .get(history_gen)
                 .cloned()
@@ -117,7 +117,10 @@ impl<T: Proposition> Membership<T> {
             let decision = if let Some(decision) = consensus.decision.as_ref() {
                 decision
             } else {
-                break;
+                panic!(
+                    "historical consensus entry without decision {}: {:?}",
+                    history_gen, consensus
+                );
             };
 
             for (reconfig, _sig) in decision.proposals.iter() {
@@ -133,15 +136,14 @@ impl<T: Proposition> Membership<T> {
     }
 
     pub fn propose(&mut self, reconfig: Reconfig<T>) -> Result<SignedVote<Reconfig<T>>> {
-        let consensus = self.consensus();
         let vote = Vote {
             gen: self.gen + 1,
             ballot: Ballot::Propose(reconfig),
-            faults: consensus.faults(),
+            faults: self.consensus.faults(),
         };
         let signed_vote = self.sign_vote(vote)?;
         self.validate_signed_vote(&signed_vote)?;
-        consensus
+        self.consensus
             .detect_byzantine_voters(&signed_vote)
             .map_err(|_| Error::AttemptedFaultyProposal)?;
         self.cast_vote(signed_vote)
@@ -151,7 +153,7 @@ impl<T: Proposition> Membership<T> {
         info!("[MBR] anti-entropy from gen {}", from_gen);
 
         let mut msgs = self
-            .consensus
+            .history
             .iter() // history is a BTreeSet, .iter() is ordered by generation
             .filter(|(gen, _)| **gen > from_gen)
             .filter_map(|(gen, c)| c.decision.clone().map(|d| (gen, c, d)))
@@ -165,13 +167,13 @@ impl<T: Proposition> Membership<T> {
             .collect::<Result<Vec<_>>>()?;
 
         // include the current in-progres votes as well.
-        msgs.extend(self.consensus().votes.values().cloned());
+        msgs.extend(self.consensus.votes.values().cloned());
 
         Ok(msgs)
     }
 
     pub fn id(&self) -> NodeId {
-        self.consensus().id()
+        self.consensus.id()
     }
 
     pub fn handle_signed_vote(
@@ -186,41 +188,36 @@ impl<T: Proposition> Membership<T> {
         let consensus = self.consensus_at_gen_mut(vote_gen).unwrap();
         let vote_response = consensus.handle_signed_vote(signed_vote)?;
 
-        if consensus.decision.is_some() {
+        if consensus.decision.is_some() && vote_gen == self.gen + 1 {
             let next_consensus = Consensus::from(
-                consensus.secret_key.clone(),
-                consensus.elders.clone(),
-                consensus.n_elders,
+                self.consensus.secret_key.clone(),
+                self.consensus.elders.clone(),
+                self.consensus.n_elders,
             );
-            self.consensus.entry(vote_gen + 1).or_insert(next_consensus);
-            self.gen = self.gen.max(vote_gen);
+
+            let decided_consensus = std::mem::replace(&mut self.consensus, next_consensus);
+            self.history.insert(vote_gen, decided_consensus);
+            self.gen = vote_gen
         }
 
         Ok(vote_response)
     }
 
     pub fn sign_vote(&self, vote: Vote<Reconfig<T>>) -> Result<SignedVote<Reconfig<T>>> {
-        self.consensus().sign_vote(vote)
+        self.consensus.sign_vote(vote)
     }
 
     pub fn cast_vote(
         &mut self,
         signed_vote: SignedVote<Reconfig<T>>,
     ) -> Result<SignedVote<Reconfig<T>>> {
-        self.consensus_mut().cast_vote(&signed_vote)?;
+        self.consensus.cast_vote(&signed_vote)?;
         self.pending_gen = signed_vote.vote.gen;
         Ok(signed_vote)
     }
 
-    pub fn count_votes(
-        &self,
-        votes: &BTreeSet<SignedVote<Reconfig<T>>>,
-    ) -> BTreeMap<BTreeSet<Reconfig<T>>, usize> {
-        self.consensus().count_votes(votes)
-    }
-
     pub fn validate_signed_vote(&self, signed_vote: &SignedVote<Reconfig<T>>) -> Result<()> {
-        if let Some(c) = self.consensus.get(&signed_vote.vote.gen) {
+        if let Some(c) = self.consensus_at_gen(signed_vote.vote.gen) {
             c.validate_signed_vote(signed_vote)?;
         } else {
             return Err(Error::VoteForBadGeneration {

--- a/src/vote.rs
+++ b/src/vote.rs
@@ -128,7 +128,7 @@ impl<T: Proposition> VoteCount<T> {
         count
     }
 
-    pub fn candidates_with_most_votes(&self) -> Option<(&Candidate<T>, usize)> {
+    pub fn candidate_with_most_votes(&self) -> Option<(&Candidate<T>, usize)> {
         self.candidates
             .iter()
             .map(|(candidates, c)| (candidates, *c))
@@ -140,7 +140,7 @@ impl<T: Proposition> VoteCount<T> {
             .max_by_key(|(_, c)| *c)
     }
 
-    pub fn super_majorities_with_most_votes(
+    pub fn super_majority_with_most_votes(
         &self,
     ) -> Option<(&Candidate<T>, &SignatureSharesByVoter<T>)> {
         self.super_majorities

--- a/tests/handover_net.rs
+++ b/tests/handover_net.rs
@@ -178,7 +178,7 @@ impl Net {
             Err(Error::NotElder) => {
                 assert_ne!(dest_proc.consensus.elders, source_elders);
             }
-            Err(Error::VoteWithInvalidUniqueSectionId { vote_gen, gen }) => {
+            Err(Error::VoteForBadGeneration { vote_gen, gen }) => {
                 assert!(vote_gen != gen);
                 assert_eq!(dest_proc.gen, gen);
             }

--- a/tests/handover_net.rs
+++ b/tests/handover_net.rs
@@ -221,17 +221,6 @@ impl Net {
             .collect();
     }
 
-    pub fn enqueue_anti_entropy(&mut self, i: usize, j: usize) {
-        let dest = self.procs[i].id();
-        let source = self.procs[j].id();
-
-        self.enqueue_packets(self.procs[j].anti_entropy().into_iter().map(|vote| Packet {
-            source,
-            dest,
-            vote,
-        }));
-    }
-
     pub fn generate_msc(&self, name: &str) -> Result<()> {
         // See: http://www.mcternan.me.uk/mscgen/
         let mut msc = String::from(

--- a/tests/membership_net.rs
+++ b/tests/membership_net.rs
@@ -91,7 +91,7 @@ impl Net {
                                     .iter()
                                     .choose(rng)
                                     .unwrap()
-                                    .consensus()
+                                    .consensus
                                     .sign(&prop)?;
                                 Ok((prop, (self.pick_id(rng), sig)))
                             })
@@ -159,7 +159,7 @@ impl Net {
 
         self.delivered_packets.push(packet.clone());
 
-        let source_elders = self.proc(source).unwrap().consensus().elders.clone();
+        let source_elders = self.proc(source).unwrap().consensus.elders.clone();
         let dest_proc = match self.procs.iter_mut().find(|p| p.id() == packet.dest) {
             Some(proc) => proc,
             None => {
@@ -178,7 +178,7 @@ impl Net {
             }
             Ok(VoteResponse::WaitingForMoreVotes) => {}
             Err(Error::NotElder) => {
-                assert_ne!(dest_proc.consensus().elders, source_elders);
+                assert_ne!(dest_proc.consensus.elders, source_elders);
             }
             Err(Error::VoteForBadGeneration {
                 vote_gen,

--- a/tests/membership_net.rs
+++ b/tests/membership_net.rs
@@ -144,10 +144,6 @@ impl Net {
         }
     }
 
-    pub fn drop_packet_from_source(&mut self, source: NodeId) {
-        self.packets.get_mut(&source).map(VecDeque::pop_front);
-    }
-
     pub fn deliver_packet_from_source(&mut self, source: NodeId) -> Result<()> {
         let packet = match self.packets.get_mut(&source).map(|ps| ps.pop_front()) {
             Some(Some(p)) => p,

--- a/tests/membership_net.rs
+++ b/tests/membership_net.rs
@@ -180,14 +180,9 @@ impl Net {
             Err(Error::NotElder) => {
                 assert_ne!(dest_proc.consensus.elders, source_elders);
             }
-            Err(Error::VoteForBadGeneration {
-                vote_gen,
-                gen,
-                pending_gen,
-            }) => {
-                assert!(vote_gen <= gen || vote_gen > pending_gen);
+            Err(Error::VoteForBadGeneration { vote_gen, gen }) => {
+                assert!(vote_gen == 0 || vote_gen > gen + 1);
                 assert_eq!(dest_proc.gen, gen);
-                assert_eq!(dest_proc.pending_gen, pending_gen);
             }
             Err(err) => return Err(err),
         }

--- a/tests/membership_net.rs
+++ b/tests/membership_net.rs
@@ -172,7 +172,7 @@ impl Net {
             Err(Error::NotElder) => {
                 assert_ne!(dest_proc.consensus.elders, source_elders);
             }
-            Err(Error::VoteNotForNextGeneration {
+            Err(Error::VoteForBadGeneration {
                 vote_gen,
                 gen,
                 pending_gen,

--- a/tests/sn_handover.rs
+++ b/tests/sn_handover.rs
@@ -186,10 +186,10 @@ fn test_handover_split_vote() -> eyre::Result<()> {
 fn test_handover_round_robin_split_vote() -> eyre::Result<()> {
     let mut rng = StdRng::from_seed([0u8; 32]);
     for nprocs in 1..7 {
-        println!("[TEST] testing with {nprocs} elders");
+        println!("[TEST] testing with {nprocs} elder(s)");
 
         // make network of nprocs elders
-        let mut net = Net::with_procs(((nprocs + 1) * 2 / 3).min(nprocs - 1), nprocs, &mut rng);
+        let mut net = Net::with_procs((2 * nprocs) / 3, nprocs, &mut rng);
 
         // make each elder propose a different thing
         for i in 0..net.procs.len() {
@@ -220,9 +220,10 @@ fn test_handover_round_robin_split_vote() -> eyre::Result<()> {
         let max_proposed_value = nprocs - 1;
         let expected_consensus_value = Some(max_proposed_value as u8);
         for i in 0..nprocs {
+            println!("proc {i}");
             let decision = net.consensus_value(i);
             println!("[TEST] checking elder {i}'s consensus value: {decision:?}");
-            assert_eq!(net.consensus_value(i), expected_consensus_value);
+            assert_eq!(decision, expected_consensus_value);
         }
     }
     Ok(())

--- a/tests/sn_handover.rs
+++ b/tests/sn_handover.rs
@@ -162,14 +162,6 @@ fn test_handover_split_vote() -> eyre::Result<()> {
         }
         net.drain_queued_packets()?;
 
-        // make elders notice split and vote for merge votes
-        for i in 0..nprocs {
-            for j in 0..nprocs {
-                net.enqueue_anti_entropy(i, j);
-            }
-        }
-        net.drain_queued_packets()?;
-
         // make sure they all reach the same conclusion
         let first_voters_value = net.consensus_value(0);
         for i in 0..nprocs {
@@ -204,14 +196,6 @@ fn test_handover_round_robin_split_vote() -> eyre::Result<()> {
                 net.deliver_packet_from_source(net.procs[i].id())?;
             }
         }
-
-        // make elders notice split and vote for merge
-        for i in 0..nprocs {
-            for j in 0..nprocs {
-                net.enqueue_anti_entropy(i, j);
-            }
-        }
-        net.drain_queued_packets()?;
 
         // generate msc file
         net.generate_msc(&format!("handover_round_robin_split_vote_{}.msc", nprocs))?;

--- a/tests/sn_handover.rs
+++ b/tests/sn_handover.rs
@@ -110,7 +110,7 @@ fn test_handover_handle_vote_rejects_packet_from_bad_gen() {
     // make sure the other elder rejects that vote
     assert!(matches!(
         net.procs[0].handle_signed_vote(vote),
-        Err(Error::VoteWithInvalidUniqueSectionId {
+        Err(Error::VoteForBadGeneration {
             vote_gen: 401,
             gen: 0,
         })

--- a/tests/sn_membership.rs
+++ b/tests/sn_membership.rs
@@ -424,7 +424,7 @@ fn test_membership_interpreter_qc2() -> Result<()> {
     let expected_members = net.procs[0].members(net.procs[0].pending_gen)?;
     for p in net.procs.iter() {
         assert_eq!(p.gen, p.pending_gen);
-        assert_eq!(p.consensus().votes, Default::default());
+        assert_eq!(p.consensus.votes, Default::default());
         assert_eq!(p.members(p.gen)?, expected_members);
     }
 
@@ -529,7 +529,7 @@ fn test_membership_interpreter_qc4() -> Result<()> {
 
     // We should have no more pending votes.
     for p in net.procs.iter() {
-        assert_eq!(p.consensus().votes, Default::default());
+        assert_eq!(p.consensus.votes, Default::default());
     }
 
     let mut procs_by_gen: BTreeMap<Generation, Vec<Membership<u8>>> = Default::default();
@@ -557,7 +557,7 @@ fn test_membership_interpreter_qc4() -> Result<()> {
     let proc_at_max_gen = procs_by_gen[max_gen].get(0).ok_or(Error::NoMembers)?;
     assert!(super_majority(
         procs_by_gen[max_gen].len(),
-        proc_at_max_gen.consensus().n_elders
+        proc_at_max_gen.consensus.n_elders
     ));
 
     Ok(())
@@ -582,14 +582,14 @@ fn test_membership_procs_refuse_to_propose_competing_votes() -> Result<()> {
         Err(Error::AttemptedFaultyProposal)
     ));
     assert!(!proc
-        .consensus()
+        .consensus
         .votes
         .get(&proc.id())
         .unwrap()
         .supersedes(&proc.sign_vote(Vote {
             ballot: Ballot::Propose(reconfig),
             gen: proc.gen,
-            faults: proc.consensus().faults(),
+            faults: proc.consensus.faults(),
         })?));
 
     Ok(())
@@ -658,7 +658,7 @@ fn test_membership_bft_consensus_qc1() -> Result<()> {
     // BFT TERMINATION PROPERTY: all honest procs have decided ==>
     for p in honest_procs.iter() {
         assert_eq!(p.gen, p.pending_gen);
-        assert_eq!(p.consensus().votes, BTreeMap::default());
+        assert_eq!(p.consensus.votes, BTreeMap::default());
     }
 
     // BFT AGREEMENT PROPERTY: all honest procs have decided on the same values
@@ -705,7 +705,7 @@ fn test_membership_bft_consensus_qc2() -> Result<()> {
 
     // BFT TERMINATION PROPERTY: all honest procs have decided ==>
     for p in honest_procs.iter() {
-        assert_eq!(p.consensus().votes, Default::default());
+        assert_eq!(p.consensus.votes, Default::default());
         assert_eq!(p.gen, p.pending_gen);
     }
 
@@ -776,7 +776,7 @@ fn test_membership_bft_consensus_qc3() -> Result<()> {
 
     // BFT TERMINATION PROPERTY: all honest procs have decided ==>
     for p in honest_procs.iter() {
-        assert_eq!(p.consensus().votes, Default::default());
+        assert_eq!(p.consensus.votes, Default::default());
         assert_eq!(p.gen, p.pending_gen);
     }
 
@@ -831,11 +831,11 @@ fn prop_interpreter(n: u8, instructions: Vec<Instruction>, seed: u128) -> eyre::
                         // This proc has already committed to a vote this round
 
                         // This proc has already committed to a vote
-                        assert!(!q.consensus().votes.get(&q.id()).unwrap().supersedes(
+                        assert!(!q.consensus.votes.get(&q.id()).unwrap().supersedes(
                             &q.sign_vote(Vote {
                                 ballot: Ballot::Propose(reconfig),
                                 gen: q.gen,
-                                faults: q.consensus().faults(),
+                                faults: q.consensus.faults(),
                             })?
                         ));
                     }
@@ -863,11 +863,11 @@ fn prop_interpreter(n: u8, instructions: Vec<Instruction>, seed: u128) -> eyre::
                     }
                     Err(Error::AttemptedFaultyProposal) => {
                         // This proc has already committed to a vote
-                        assert!(!q.consensus().votes.get(&q.id()).unwrap().supersedes(
+                        assert!(!q.consensus.votes.get(&q.id()).unwrap().supersedes(
                             &q.sign_vote(Vote {
                                 ballot: Ballot::Propose(reconfig),
                                 gen: q.gen,
-                                faults: q.consensus().faults(),
+                                faults: q.consensus.faults(),
                             })
                             .unwrap()
                         ))
@@ -901,7 +901,7 @@ fn prop_interpreter(n: u8, instructions: Vec<Instruction>, seed: u128) -> eyre::
 
     // We should have no more pending votes.
     for p in net.procs.iter() {
-        assert_eq!(p.consensus().votes, Default::default());
+        assert_eq!(p.consensus.votes, Default::default());
     }
 
     let mut procs_by_gen: BTreeMap<Generation, Vec<Membership<u8>>> = Default::default();
@@ -932,7 +932,7 @@ fn prop_interpreter(n: u8, instructions: Vec<Instruction>, seed: u128) -> eyre::
     let proc_at_max_gen = procs_by_gen[max_gen].get(0).ok_or(Error::NoMembers)?;
     assert!(super_majority(
         procs_by_gen[max_gen].len(),
-        proc_at_max_gen.consensus().n_elders
+        proc_at_max_gen.consensus.n_elders
     ));
 
     Ok(TestResult::passed())
@@ -1090,7 +1090,7 @@ fn prop_bft_consensus(
 
     // BFT TERMINATION PROPERTY: all honest procs have decided ==>
     for p in honest_procs.iter() {
-        assert_eq!(p.consensus().votes, Default::default());
+        assert_eq!(p.consensus.votes, Default::default());
         assert_eq!(p.gen, p.pending_gen);
     }
 

--- a/tests/sn_membership.rs
+++ b/tests/sn_membership.rs
@@ -18,8 +18,17 @@ use sn_membership::{
     Ballot, Error, Generation, Membership, Reconfig, Result, SignedVote, Vote, VoteResponse,
 };
 
+static INIT: std::sync::Once = std::sync::Once::new();
+
+fn init() {
+    INIT.call_once(|| {
+        let _ = env_logger::builder().is_test(true).try_init();
+    });
+}
+
 #[test]
 fn test_membership_reject_changing_reconfig_when_one_is_in_progress() -> Result<()> {
+    init();
     let mut rng = StdRng::from_seed([0u8; 32]);
     let elders_sk = SecretKeySet::random(0, &mut rng);
     let mut proc = Membership::<u8>::from(
@@ -37,6 +46,7 @@ fn test_membership_reject_changing_reconfig_when_one_is_in_progress() -> Result<
 
 #[test]
 fn test_membership_reject_vote_from_non_member() -> Result<()> {
+    init();
     let mut rng = StdRng::from_seed([0u8; 32]);
     let elders_sk = SecretKeySet::random(0, &mut rng);
     let mut p0 = Membership::<u8>::from(
@@ -59,6 +69,7 @@ fn test_membership_reject_vote_from_non_member() -> Result<()> {
 
 #[test]
 fn test_membership_reject_join_if_actor_is_already_a_member() {
+    init();
     let mut rng = StdRng::from_seed([0u8; 32]);
     let elders_sk = SecretKeySet::random(0, &mut rng);
     let mut proc = Membership::from(
@@ -76,6 +87,7 @@ fn test_membership_reject_join_if_actor_is_already_a_member() {
 
 #[test]
 fn test_membership_reject_leave_if_actor_is_not_a_member() {
+    init();
     let mut rng = StdRng::from_seed([0u8; 32]);
     let elders_sk = SecretKeySet::random(0, &mut rng);
     let mut proc = Membership::from(
@@ -93,6 +105,7 @@ fn test_membership_reject_leave_if_actor_is_not_a_member() {
 
 #[test]
 fn test_membership_returns_catchup_packets_from_previous_gen() -> Result<()> {
+    init();
     let mut rng = StdRng::from_seed([0u8; 32]);
     let mut net = Net::with_procs(0, 2, &mut rng);
 
@@ -153,6 +166,7 @@ fn test_membership_returns_catchup_packets_from_previous_gen() -> Result<()> {
 
 #[test]
 fn test_membership_reject_votes_with_invalid_signatures() -> Result<()> {
+    init();
     let mut rng = StdRng::from_seed([0u8; 32]);
     let elders_sk = SecretKeySet::random(0, &mut rng);
     let mut proc = Membership::<u8>::from(
@@ -177,6 +191,7 @@ fn test_membership_reject_votes_with_invalid_signatures() -> Result<()> {
 
 #[test]
 fn test_membership_split_vote() -> Result<()> {
+    init();
     let mut rng = StdRng::from_seed([0u8; 32]);
     for nprocs in 1..7 {
         let mut net = Net::with_procs((nprocs * 2) / 3, nprocs, &mut rng);
@@ -207,6 +222,7 @@ fn test_membership_split_vote() -> Result<()> {
 
 #[test]
 fn test_membership_round_robin_split_vote() -> Result<()> {
+    init();
     let mut rng = StdRng::from_seed([0u8; 32]);
     for nprocs in 1..7 {
         let mut net = Net::with_procs(((nprocs + 1) * 2 / 3).min(nprocs - 1), nprocs, &mut rng);
@@ -240,6 +256,7 @@ fn test_membership_round_robin_split_vote() -> Result<()> {
 
 #[test]
 fn test_membership_onboarding_across_many_generations() -> Result<()> {
+    init();
     let mut rng = StdRng::from_seed([0u8; 32]);
     let mut net = Net::with_procs(1, 2, &mut rng);
     let p0 = net.procs[0].id();
@@ -285,6 +302,7 @@ fn test_membership_onboarding_across_many_generations() -> Result<()> {
 
 #[test]
 fn test_membership_simple_proposal() -> Result<()> {
+    init();
     let mut rng = StdRng::from_seed([0u8; 32]);
     let mut net = Net::with_procs(2, 3, &mut rng);
 
@@ -377,6 +395,7 @@ impl Arbitrary for Instruction {
 
 #[test]
 fn test_membership_interpreter_qc1() -> Result<()> {
+    init();
     let mut rng = StdRng::from_seed([0u8; 32]);
     let mut net = Net::with_procs(1, 2, &mut rng);
     let p0 = net.procs[0].id();
@@ -399,6 +418,7 @@ fn test_membership_interpreter_qc1() -> Result<()> {
 
 #[test]
 fn test_membership_interpreter_qc2() -> Result<()> {
+    init();
     let mut rng = StdRng::from_seed([0u8; 32]);
     let mut net = Net::with_procs(2, 3, &mut rng);
     let p0 = net.procs[0].id();
@@ -427,6 +447,7 @@ fn test_membership_interpreter_qc2() -> Result<()> {
 
 #[test]
 fn test_membership_interpreter_qc3() {
+    init();
     let mut rng = StdRng::from_seed([0u8; 32]);
     let mut net = Net::with_procs(3, 4, &mut rng);
 
@@ -473,6 +494,7 @@ fn test_membership_interpreter_qc3() {
 
 #[test]
 fn test_membership_interpreter_qc4() -> Result<()> {
+    init();
     let mut rng = StdRng::from_seed([0u8; 32]);
 
     fn super_majority(m: usize, n: usize) -> bool {
@@ -559,6 +581,7 @@ fn test_membership_interpreter_qc4() -> Result<()> {
 
 #[test]
 fn test_membership_procs_refuse_to_propose_competing_votes() -> Result<()> {
+    init();
     let mut rng = StdRng::from_seed([0u8; 32]);
     let elders_sk = SecretKeySet::random(0, &mut rng);
     let mut proc = Membership::<u8>::from(
@@ -591,6 +614,7 @@ fn test_membership_procs_refuse_to_propose_competing_votes() -> Result<()> {
 
 #[test]
 fn test_membership_validate_reconfig_rejects_when_members_at_capacity() -> Result<()> {
+    init();
     let mut rng = StdRng::from_seed([0u8; 32]);
     let elders_sk = SecretKeySet::random(0, &mut rng);
     let mut proc = Membership::<u8>::from(
@@ -613,6 +637,7 @@ fn test_membership_validate_reconfig_rejects_when_members_at_capacity() -> Resul
 
 #[test]
 fn test_membership_bft_consensus_qc1() -> Result<()> {
+    init();
     let mut rng = rand::rngs::StdRng::from_seed([0u8; 32]);
     let mut net = Net::with_procs(4, 6, &mut rng);
     let faulty = BTreeSet::from_iter([net.procs[1].id(), net.procs[5].id()]);
@@ -672,6 +697,7 @@ fn test_membership_bft_consensus_qc1() -> Result<()> {
 
 #[test]
 fn test_membership_bft_consensus_qc2() -> Result<()> {
+    init();
     let mut rng = rand::rngs::StdRng::from_seed([0u8; 32]);
     let mut net = Net::with_procs(3, 5, &mut rng);
     let faulty = BTreeSet::from_iter([net.procs[0].id()]);
@@ -797,6 +823,7 @@ fn test_membership_bft_consensus_qc3() -> Result<()> {
 
 #[quickcheck]
 fn prop_interpreter(n: u8, instructions: Vec<Instruction>, seed: u128) -> eyre::Result<TestResult> {
+    init();
     let mut seed_buf = [0u8; 32];
     seed_buf[0..16].copy_from_slice(&seed.to_le_bytes());
     let mut rng = StdRng::from_seed(seed_buf);
@@ -949,6 +976,7 @@ fn prop_validate_reconfig(
     threshold: u8,
     seed: u128,
 ) -> Result<TestResult> {
+    init();
     let mut seed_buf = [0u8; 32];
     seed_buf[0..16].copy_from_slice(&seed.to_le_bytes());
     let mut rng = StdRng::from_seed(seed_buf);
@@ -1010,6 +1038,7 @@ fn prop_bft_consensus(
     faulty: Vec<u8>,
     seed: u128,
 ) -> Result<TestResult> {
+    init();
     let n = n % 6 + 1;
     let recursion_limit = recursion_limit % (n / 2).max(1);
     let faulty = BTreeSet::from_iter(


### PR DESCRIPTION
Prop tests found a few issues over the weekend, fixing those lead to a few cascading changes that overall make things a bit simpler for us:
1. `count_votes` was not filtering out old votes from voters, fix was to count only the most recent vote from each voter.
2. We were detecting faulty voters but we were not dropping their votes, now we explicitly check if a voter is faulty and drop their votes.
3. We now have an explicit idempotency check for votes we've already handled.
4. We now recursively process the votes we make before returning them to the caller, this is needed now that we have idempotent checks in place
5. in `sn_membership` we now keep a history of past sn_consensus states, we route votes to their corresponding consensus state.
6. we've removed the `pending_gen` field as it can be derived from other state (i.e. check if the current consensus state has votes)
7. `handle_signed_vote` was taking the generation as input, this opened us up to user error if the wrong generation was passed in. Now we read the generation from the passed in vote.